### PR TITLE
[BACK-4437] Add Keycloak trusted-device SPI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "keycloak-spi-trusted-device"]
+	path = keycloak-spi-trusted-device
+	url = git@github.com:tidepool-org/keycloak-spi-trusted-device.git

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Drevision=LATEST

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.5-openjdk-17 as build
+FROM maven:3.8.5-openjdk-17 AS build
 
 COPY . /build
 WORKDIR /build
@@ -9,15 +9,16 @@ RUN microdnf update \
  && rm -rf /var/cache/yum
 
 RUN unset MAVEN_CONFIG && \
-    ./mvnw versions:set -DnewVersion=LATEST && \
+    ./mvnw versions:set -DnewVersion=LATEST -Drevision=LATEST && \
     ./mvnw install && \
     ./mvnw clean compile package && \
     wget -O keycloak-rest-provider.jar https://github.com/daniel-frak/keycloak-user-migration/releases/download/6.2.1/keycloak-rest-provider-6.2.1.jar && \
     wget -O keycloak-metrics-spi.jar https://github.com/aerogear/keycloak-metrics-spi/releases/download/7.0.0/keycloak-metrics-spi-7.0.0.jar && \
     wget -O keycloak-home-idp-discovery.jar https://github.com/tidepool-org/keycloak-home-idp-discovery/releases/download/v26.6.1/keycloak-home-idp-discovery.jar
 
-FROM alpine:latest as release
+FROM alpine:latest AS release
 
 COPY --from=build /build/admin/target/*.jar /release/extensions/
+COPY --from=build /build/keycloak-spi-trusted-device/spi/target/keycloak-spi-trusted-device-LATEST.jar /release/extensions/
 COPY --from=build /build/*.jar /release/extensions/
 COPY ./tidepool-theme /release/tidepool-theme

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ image_tag := $(keycloak_version)-$(date)
 build-artifacts:
 	./mvnw clean compile package
 
+
 # Builds the docker image
 build: build-artifacts
 	docker build --platform linux/amd64 --tag tidepool/keycloak-extensions:$(image_tag) .

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 
     <modules>
         <module>admin</module>
+        <module>keycloak-spi-trusted-device</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Introduces the `keycloak-spi-trusted-device` submodule + reactor module and the Docker/Maven wiring to build and ship it (foundation for the "trust this device" 2FA flow). Also makes the device name optional.

---
📚 **Stacked PR 1 of 8.** Base branch: `master`

**Stack — review & merge bottom-up:**

1. `tk-stack-1-trusted-device-spi` → `master`
2. `tk-stack-2-attempted-username-fix` → `tk-stack-1-trusted-device-spi`
3. `tk-stack-3-aia-authenticator` → `tk-stack-2-attempted-username-fix`
4. `tk-stack-4-2fa-cleanup-listeners` → `tk-stack-3-aia-authenticator`
5. `tk-stack-5-login-activity-outbox` → `tk-stack-4-2fa-cleanup-listeners`
6. `tk-stack-6-email-changed-notification` → `tk-stack-5-login-activity-outbox`
7. `tk-stack-7-cancelable-email-change` → `tk-stack-6-email-changed-notification`
8. `tk-stack-8-theme-redesign` → `tk-stack-7-cancelable-email-change`

_Builds green on JDK 21 (`./mvnw clean compile package`); on the stack tip 42 admin + 35 home-idp tests pass._