### PR TITLE
[BACK-4437] Fix attempted username persisting on the initial login page

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "keycloak-spi-trusted-device"]
 	path = keycloak-spi-trusted-device
 	url = git@github.com:tidepool-org/keycloak-spi-trusted-device.git
+[submodule "keycloak-home-idp-discovery"]
+	path = keycloak-home-idp-discovery
+	url = git@github.com:tidepool-org/keycloak-home-idp-discovery.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,12 @@ RUN unset MAVEN_CONFIG && \
     ./mvnw install && \
     ./mvnw clean compile package && \
     wget -O keycloak-rest-provider.jar https://github.com/daniel-frak/keycloak-user-migration/releases/download/6.2.1/keycloak-rest-provider-6.2.1.jar && \
-    wget -O keycloak-metrics-spi.jar https://github.com/aerogear/keycloak-metrics-spi/releases/download/7.0.0/keycloak-metrics-spi-7.0.0.jar && \
-    wget -O keycloak-home-idp-discovery.jar https://github.com/tidepool-org/keycloak-home-idp-discovery/releases/download/v26.6.1/keycloak-home-idp-discovery.jar
+    wget -O keycloak-metrics-spi.jar https://github.com/aerogear/keycloak-metrics-spi/releases/download/7.0.0/keycloak-metrics-spi-7.0.0.jar
 
 FROM alpine:latest AS release
 
 COPY --from=build /build/admin/target/*.jar /release/extensions/
 COPY --from=build /build/keycloak-spi-trusted-device/spi/target/keycloak-spi-trusted-device-LATEST.jar /release/extensions/
+COPY --from=build /build/keycloak-home-idp-discovery/target/keycloak-home-idp-discovery.jar /release/extensions/
 COPY --from=build /build/*.jar /release/extensions/
 COPY ./tidepool-theme /release/tidepool-theme

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,13 @@ keycloak_version = 26.6.1
 date := $(shell date -u +"%Y-%m-%dT%H-%M-%S")
 image_tag := $(keycloak_version)-$(date)
 
-build-artifacts:
+.PHONY: submodules
+submodules:
+	@git submodule status | awk '/^-/ {print $$2}' | while read path; do \
+		[ -n "$$path" ] && git submodule update --init "$$path"; \
+	done
+
+build-artifacts: submodules
 	./mvnw clean compile package
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ volumes:
     driver: local
   postgres_data:
     driver: local
+  maven_cache:
+    driver: local
 
 services:
   postgres:
@@ -18,13 +20,15 @@ services:
       - 6543:5432
 
   providers:
-    image: alpine:3.20.3
+    image: maven:3.8.5-openjdk-17
+    working_dir: /build
     command: [
       "/bin/sh",
       "-c",
-      "apk add ca-certificates && update-ca-certificates && rm -f /providers/* && cp /local/admin.jar /providers && wget -O /providers/keycloak-home-idp-discovery.jar https://github.com/tidepool-org/keycloak-home-idp-discovery/releases/download/v26.6.1/keycloak-home-idp-discovery.jar"]
+      "git submodule status | awk '/^-/ {print $$2}' | xargs -r -I{} git submodule update --init -- {} && ./mvnw -B clean package -pl admin,keycloak-home-idp-discovery,keycloak-spi-trusted-device/spi -am -DskipTests && rm -f /providers/* && cp admin/target/admin-LATEST.jar /providers/ && cp keycloak-home-idp-discovery/target/keycloak-home-idp-discovery.jar /providers/ && cp keycloak-spi-trusted-device/spi/target/keycloak-spi-trusted-device-*.jar /providers/ && curl -fsSL -o /providers/keycloak-rest-provider.jar https://github.com/daniel-frak/keycloak-user-migration/releases/download/6.2.1/keycloak-rest-provider-6.2.1.jar"]
     volumes:
-      - ./admin/target/admin-LATEST.jar:/local/admin.jar
+      - .:/build
+      - maven_cache:/root/.m2
       - providers:/providers
 
   keycloak:

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <modules>
         <module>admin</module>
         <module>keycloak-spi-trusted-device</module>
+        <module>keycloak-home-idp-discovery</module>
     </modules>
 
     <build>

--- a/tidepool-theme/login/template.ftl
+++ b/tidepool-theme/login/template.ftl
@@ -123,7 +123,11 @@
                     <img class="logo" src="${url.resourcesPath}/img/tidepool-logo-890x96.png" alt="Tidepool"/>
                 </#if>
             </a>
-        <#if !(auth?has_content && auth.showUsername() && !auth.showResetCredentials())>
+        <#-- Skip the disabled "attempted username" header on login-username.ftl: the home-idp-discovery -->
+        <#-- authenticator pre-populates the email via login_hint, which makes auth.showUsername() true even -->
+        <#-- on the first step. The page already renders an editable username input, so the disabled one -->
+        <#-- would duplicate it (two elements with id="username"). -->
+        <#if !(auth?has_content && auth.showUsername() && !auth.showResetCredentials()) || (pageId?? && pageId == 'login-username')>
             <#if displayRequiredFields>
                 <div class="${properties.kcContentWrapperClass!}">
                     <div class="${properties.kcLabelWrapperClass!} subtitle">


### PR DESCRIPTION
Fixes the attempted username being rendered on the initial login page even after a reset. Bumps the `keycloak-home-idp-discovery` submodule and adds it to the reactor.

---
📚 **Stacked PR 2 of 8.** Base branch: `tk-stack-1-trusted-device-spi` — review/merge it first.

**Stack — review & merge bottom-up:**

1. `tk-stack-1-trusted-device-spi` → `master`
2. `tk-stack-2-attempted-username-fix` → `tk-stack-1-trusted-device-spi`
3. `tk-stack-3-aia-authenticator` → `tk-stack-2-attempted-username-fix`
4. `tk-stack-4-2fa-cleanup-listeners` → `tk-stack-3-aia-authenticator`
5. `tk-stack-5-login-activity-outbox` → `tk-stack-4-2fa-cleanup-listeners`
6. `tk-stack-6-email-changed-notification` → `tk-stack-5-login-activity-outbox`
7. `tk-stack-7-cancelable-email-change` → `tk-stack-6-email-changed-notification`
8. `tk-stack-8-theme-redesign` → `tk-stack-7-cancelable-email-change`

_Builds green on JDK 21 (`./mvnw clean compile package`); on the stack tip 42 admin + 35 home-idp tests pass._