### PR TITLE
[BACK-4437] Add AIA conditional authenticator

### DIFF
--- a/admin/src/main/java/org/tidepool/keycloak/extensions/authenticator/ConditionAppInitiatedAction.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/authenticator/ConditionAppInitiatedAction.java
@@ -1,0 +1,63 @@
+package org.tidepool.keycloak.extensions.authenticator;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+public class ConditionAppInitiatedAction implements ConditionalAuthenticator {
+
+    @Override
+    public boolean matchCondition(AuthenticationFlowContext context) {
+        boolean isAia = isAppInitiatedAction(context.getAuthenticationSession());
+
+        AuthenticatorConfigModel authConfig = context.getAuthenticatorConfig();
+        if (authConfig != null && authConfig.getConfig() != null) {
+            boolean negateOutput = Boolean.parseBoolean(authConfig.getConfig().get(ConditionAppInitiatedActionFactory.CONF_NEGATE));
+            return negateOutput != isAia;
+        }
+
+        return isAia;
+    }
+
+    /**
+     * The OIDC AuthorizationEndpoint stores the {@code kc_action} query
+     * parameter on the auth session as a client note before the browser flow
+     * starts. The note is also re-set during action execution. Either presence
+     * is enough to identify an AIA-driven flow.
+     */
+    private static boolean isAppInitiatedAction(AuthenticationSessionModel authSession) {
+        if (authSession == null) {
+            return false;
+        }
+        String kcAction = authSession.getClientNote(Constants.KC_ACTION);
+        if (kcAction == null || kcAction.isEmpty()) {
+            kcAction = authSession.getClientNote(Constants.KC_ACTION_EXECUTING);
+        }
+        return kcAction != null && !kcAction.isEmpty();
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        // Not used
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+        // Not used
+    }
+
+    @Override
+    public void close() {
+        // Not used
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/authenticator/ConditionAppInitiatedAction.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/authenticator/ConditionAppInitiatedAction.java
@@ -15,13 +15,20 @@ public class ConditionAppInitiatedAction implements ConditionalAuthenticator {
     public boolean matchCondition(AuthenticationFlowContext context) {
         boolean isAia = isAppInitiatedAction(context.getAuthenticationSession());
 
+        // Negate defaults to TRUE to match the factory's UI default. Without this,
+        // admins who add the condition but never click Save in the config dialog
+        // get the opposite of the documented behavior — the config map is empty
+        // and Boolean.parseBoolean(null) is false.
+        boolean negateOutput = true;
         AuthenticatorConfigModel authConfig = context.getAuthenticatorConfig();
         if (authConfig != null && authConfig.getConfig() != null) {
-            boolean negateOutput = Boolean.parseBoolean(authConfig.getConfig().get(ConditionAppInitiatedActionFactory.CONF_NEGATE));
-            return negateOutput != isAia;
+            String configured = authConfig.getConfig().get(ConditionAppInitiatedActionFactory.CONF_NEGATE);
+            if (configured != null) {
+                negateOutput = Boolean.parseBoolean(configured);
+            }
         }
 
-        return isAia;
+        return negateOutput != isAia;
     }
 
     /**

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/authenticator/ConditionAppInitiatedActionFactory.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/authenticator/ConditionAppInitiatedActionFactory.java
@@ -1,0 +1,106 @@
+package org.tidepool.keycloak.extensions.authenticator;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ServerInfoAwareProviderFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.keycloak.models.AuthenticationExecutionModel.Requirement.DISABLED;
+import static org.keycloak.models.AuthenticationExecutionModel.Requirement.REQUIRED;
+
+/**
+ * Conditional authenticator that matches when the current authentication flow
+ * was started by an Application-Initiated Action (AIA) — i.e. the OIDC client
+ * passed the {@code kc_action} query parameter (e.g. {@code UPDATE_PASSWORD}).
+ *
+ * <p>Wrap an authenticator like OTP in a CONDITIONAL subflow with this
+ * condition + {@code Negate output = true} (the default) to <em>skip</em> the
+ * authenticator during AIA re-auth while still requiring it on regular logins.
+ */
+public final class ConditionAppInitiatedActionFactory implements AuthenticatorFactory, ServerInfoAwareProviderFactory {
+
+    private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = new AuthenticationExecutionModel.Requirement[]{REQUIRED, DISABLED};
+
+    private static final String PROVIDER_ID = "condition-app-initiated-action";
+
+    public static final String CONF_NEGATE = "negate";
+
+    @Override
+    public String getDisplayType() {
+        return "Condition - App-Initiated Action";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return "Authorization";
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Matches when the authentication flow was triggered by an Application-Initiated Action (kc_action). Useful for skipping authenticators like OTP during AIA re-auth.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        ProviderConfigProperty negate = new ProviderConfigProperty();
+        negate.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        negate.setName(CONF_NEGATE);
+        negate.setLabel("Negate output");
+        negate.setDefaultValue(Boolean.toString(true));
+        negate.setHelpText("Apply a NOT to the check result. When this is true, the condition evaluates to true when the flow was NOT triggered by an Application-Initiated Action.");
+        return List.of(negate);
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return new ConditionAppInitiatedAction();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public Map<String, String> getOperationalInfo() {
+        String version = getClass().getPackage().getImplementationVersion();
+        if (version == null) {
+            version = "dev-snapshot";
+        }
+        return Map.of("Version", version);
+    }
+}

--- a/admin/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/admin/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,3 +1,4 @@
+org.tidepool.keycloak.extensions.authenticator.ConditionAppInitiatedActionFactory
 org.tidepool.keycloak.extensions.authenticator.ConditionUserInContextFactory
 org.tidepool.keycloak.extensions.authenticator.IdpDetectExistingBrokerUserAuthenticatorCustomErrorFactory
 org.tidepool.keycloak.extensions.authenticator.RedirectToRegistrationPageFactory


### PR DESCRIPTION
Adds the `ConditionAppInitiatedAction` authenticator + factory for conditionally running an AIA flow.

> **Backend only.** The original commit also trimmed the TOTP setup page; that theme hunk was moved to the theme-redesign PR (`tk-stack-8-theme-redesign`) to keep Java and theme concerns separate.

---
📚 **Stacked PR 3 of 8.** Base branch: `tk-stack-2-attempted-username-fix` — review/merge it first.

**Stack — review & merge bottom-up:**

1. `tk-stack-1-trusted-device-spi` → `master`
2. `tk-stack-2-attempted-username-fix` → `tk-stack-1-trusted-device-spi`
3. `tk-stack-3-aia-authenticator` → `tk-stack-2-attempted-username-fix`
4. `tk-stack-4-2fa-cleanup-listeners` → `tk-stack-3-aia-authenticator`
5. `tk-stack-5-login-activity-outbox` → `tk-stack-4-2fa-cleanup-listeners`
6. `tk-stack-6-email-changed-notification` → `tk-stack-5-login-activity-outbox`
7. `tk-stack-7-cancelable-email-change` → `tk-stack-6-email-changed-notification`
8. `tk-stack-8-theme-redesign` → `tk-stack-7-cancelable-email-change`

_Builds green on JDK 21 (`./mvnw clean compile package`); on the stack tip 42 admin + 35 home-idp tests pass._