### PR TITLE
[BACK-4441] Add 2FA cleanup event listeners (recovery codes + trusted devices)

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -63,6 +63,32 @@
             <artifactId>auto-service</artifactId>
             <version>1.0.1</version>
         </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.23.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.27.7</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -71,6 +97,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/events/RecoveryCodesCleanupEventListenerProvider.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/events/RecoveryCodesCleanupEventListenerProvider.java
@@ -1,0 +1,93 @@
+package org.tidepool.keycloak.extensions.events;
+
+import org.jboss.logging.Logger;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventType;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.SubjectCredentialManager;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.credential.OTPCredentialModel;
+import org.keycloak.models.credential.RecoveryAuthnCodesCredentialModel;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Deletes a user's recovery authentication codes once their last OTP device is removed.
+ *
+ * <p>Tidepool issues recovery codes only as a backup for OTP-based two-factor authentication.
+ * Leaving them behind after every OTP credential is gone would let a user keep a second factor
+ * they can no longer use to enrol an authenticator, so we clean them up.
+ *
+ * <p>When a user removes an OTP device via self-service (the account console or an app-initiated
+ * action), Keycloak fires {@link EventType#REMOVE_TOTP} <em>after</em> the credential has already
+ * been deleted from the store. At that point we count the remaining OTP credentials; if none
+ * remain, the recovery codes are removed too. Admin-initiated credential removals are intentionally
+ * out of scope (the admin event carries no credential type), so this only reacts to user events.
+ */
+public class RecoveryCodesCleanupEventListenerProvider implements EventListenerProvider {
+
+    private static final Logger LOG = Logger.getLogger(RecoveryCodesCleanupEventListenerProvider.class);
+
+    private final KeycloakSession session;
+
+    public RecoveryCodesCleanupEventListenerProvider(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        if (event.getType() != EventType.REMOVE_TOTP) {
+            return;
+        }
+        deleteRecoveryCodesIfNoOtpRemains(event.getRealmId(), event.getUserId());
+    }
+
+    @Override
+    public void onEvent(AdminEvent event, boolean includeRepresentation) {
+        // Self-service OTP removals only; admin-initiated credential removals are out of scope.
+    }
+
+    private void deleteRecoveryCodesIfNoOtpRemains(String realmId, String userId) {
+        if (realmId == null || userId == null) {
+            return;
+        }
+
+        RealmModel realm = session.realms().getRealm(realmId);
+        if (realm == null) {
+            return;
+        }
+
+        UserModel user = session.users().getUserById(realm, userId);
+        if (user == null) {
+            return;
+        }
+
+        SubjectCredentialManager credentials = user.credentialManager();
+        boolean hasOtp = credentials.getStoredCredentialsByTypeStream(OTPCredentialModel.TYPE).findAny().isPresent();
+        if (hasOtp) {
+            return;
+        }
+
+        List<String> recoveryCodeIds = credentials
+                .getStoredCredentialsByTypeStream(RecoveryAuthnCodesCredentialModel.TYPE)
+                .map(CredentialModel::getId)
+                .collect(Collectors.toList());
+
+        if (recoveryCodeIds.isEmpty()) {
+            return;
+        }
+
+        recoveryCodeIds.forEach(credentials::removeStoredCredentialById);
+        LOG.infof("Removed %d recovery-code credential(s) for user %s in realm %s after the last OTP device was deleted",
+                recoveryCodeIds.size(), userId, realm.getName());
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/events/RecoveryCodesCleanupEventListenerProviderFactory.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/events/RecoveryCodesCleanupEventListenerProviderFactory.java
@@ -1,0 +1,49 @@
+package org.tidepool.keycloak.extensions.events;
+
+import com.google.auto.service.AutoService;
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * Registers {@link RecoveryCodesCleanupEventListenerProvider}.
+ *
+ * <p>This is a {@linkplain #isGlobal() global} event listener, so it runs for every realm without
+ * any per-realm configuration &mdash; there is no need to add {@value #PROVIDER_ID} to a realm's
+ * event listeners.
+ */
+@AutoService(EventListenerProviderFactory.class)
+public class RecoveryCodesCleanupEventListenerProviderFactory implements EventListenerProviderFactory {
+
+    public static final String PROVIDER_ID = "tidepool-recovery-codes-cleanup";
+
+    @Override
+    public EventListenerProvider create(KeycloakSession session) {
+        return new RecoveryCodesCleanupEventListenerProvider(session);
+    }
+
+    @Override
+    public boolean isGlobal() {
+        // Always active for all realms; no per-realm "eventsListeners" entry required.
+        return true;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/events/TrustedDeviceCleanupEventListenerProvider.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/events/TrustedDeviceCleanupEventListenerProvider.java
@@ -1,0 +1,95 @@
+package org.tidepool.keycloak.extensions.events;
+
+import org.jboss.logging.Logger;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventType;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.SubjectCredentialManager;
+import org.keycloak.models.UserModel;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Removes all of a user's trusted devices when their password changes.
+ *
+ * <p>A trusted device lets a user skip two-factor authentication on a previously verified device.
+ * When the password changes &mdash; whether the user updates it themselves or completes a
+ * forgot-password reset &mdash; any existing trust should be revoked, so a new password cannot ride
+ * on a device that was trusted under the old one.
+ *
+ * <p>Keycloak fires {@link EventType#UPDATE_PASSWORD} after the password has been set, for both the
+ * self-service "update password" action and the reset-credentials (forgot-password) flow. We react
+ * by deleting every stored {@value #TRUSTED_DEVICE_CREDENTIAL_TYPE} credential for the user, which
+ * is how the trusted-device SPI persists trust. Admin-initiated password resets emit only an admin
+ * event and are intentionally out of scope.
+ */
+public class TrustedDeviceCleanupEventListenerProvider implements EventListenerProvider {
+
+    private static final Logger LOG = Logger.getLogger(TrustedDeviceCleanupEventListenerProvider.class);
+
+    /**
+     * Credential type persisted by the trusted-device SPI
+     * ({@code nl.wouterh.keycloak.trusteddevice.credential.TrustedDeviceCredentialModel.TYPE_TWOFACTOR}).
+     * Hard-coded so this module need not depend on the trusted-device submodule; the value is a
+     * stored credential type and is therefore a stable contract.
+     */
+    static final String TRUSTED_DEVICE_CREDENTIAL_TYPE = "trusted-device";
+
+    private final KeycloakSession session;
+
+    public TrustedDeviceCleanupEventListenerProvider(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        if (event.getType() != EventType.UPDATE_PASSWORD) {
+            return;
+        }
+        removeTrustedDevices(event.getRealmId(), event.getUserId());
+    }
+
+    @Override
+    public void onEvent(AdminEvent event, boolean includeRepresentation) {
+        // Self-service / reset-credentials password changes only; admin password resets are out of scope.
+    }
+
+    private void removeTrustedDevices(String realmId, String userId) {
+        if (realmId == null || userId == null) {
+            return;
+        }
+
+        RealmModel realm = session.realms().getRealm(realmId);
+        if (realm == null) {
+            return;
+        }
+
+        UserModel user = session.users().getUserById(realm, userId);
+        if (user == null) {
+            return;
+        }
+
+        SubjectCredentialManager credentials = user.credentialManager();
+        List<String> trustedDeviceIds = credentials
+                .getStoredCredentialsByTypeStream(TRUSTED_DEVICE_CREDENTIAL_TYPE)
+                .map(CredentialModel::getId)
+                .collect(Collectors.toList());
+
+        if (trustedDeviceIds.isEmpty()) {
+            return;
+        }
+
+        trustedDeviceIds.forEach(credentials::removeStoredCredentialById);
+        LOG.infof("Removed %d trusted device(s) for user %s in realm %s after a password change",
+                trustedDeviceIds.size(), userId, realm.getName());
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/events/TrustedDeviceCleanupEventListenerProviderFactory.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/events/TrustedDeviceCleanupEventListenerProviderFactory.java
@@ -1,0 +1,49 @@
+package org.tidepool.keycloak.extensions.events;
+
+import com.google.auto.service.AutoService;
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * Registers {@link TrustedDeviceCleanupEventListenerProvider}.
+ *
+ * <p>This is a {@linkplain #isGlobal() global} event listener, so it runs for every realm without
+ * any per-realm configuration &mdash; there is no need to add {@value #PROVIDER_ID} to a realm's
+ * event listeners.
+ */
+@AutoService(EventListenerProviderFactory.class)
+public class TrustedDeviceCleanupEventListenerProviderFactory implements EventListenerProviderFactory {
+
+    public static final String PROVIDER_ID = "tidepool-trusted-device-cleanup";
+
+    @Override
+    public EventListenerProvider create(KeycloakSession session) {
+        return new TrustedDeviceCleanupEventListenerProvider(session);
+    }
+
+    @Override
+    public boolean isGlobal() {
+        // Always active for all realms; no per-realm "eventsListeners" entry required.
+        return true;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/admin/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/admin/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -1,0 +1,1 @@
+org.tidepool.keycloak.extensions.events.RecoveryCodesCleanupEventListenerProviderFactory

--- a/admin/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/admin/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -1,1 +1,2 @@
 org.tidepool.keycloak.extensions.events.RecoveryCodesCleanupEventListenerProviderFactory
+org.tidepool.keycloak.extensions.events.TrustedDeviceCleanupEventListenerProviderFactory

--- a/admin/src/test/java/org/tidepool/keycloak/extensions/events/RecoveryCodesCleanupEventListenerProviderTest.java
+++ b/admin/src/test/java/org/tidepool/keycloak/extensions/events/RecoveryCodesCleanupEventListenerProviderTest.java
@@ -1,0 +1,120 @@
+package org.tidepool.keycloak.extensions.events;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RealmProvider;
+import org.keycloak.models.SubjectCredentialManager;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
+import org.keycloak.models.credential.OTPCredentialModel;
+import org.keycloak.models.credential.RecoveryAuthnCodesCredentialModel;
+
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RecoveryCodesCleanupEventListenerProviderTest {
+
+    private static final String REALM_ID = "realm-1";
+    private static final String USER_ID = "user-1";
+
+    private KeycloakSession session;
+    private SubjectCredentialManager credentials;
+    private RecoveryCodesCleanupEventListenerProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        session = mock(KeycloakSession.class);
+        RealmProvider realms = mock(RealmProvider.class);
+        UserProvider users = mock(UserProvider.class);
+        RealmModel realm = mock(RealmModel.class);
+        UserModel user = mock(UserModel.class);
+        credentials = mock(SubjectCredentialManager.class);
+
+        lenient().when(session.realms()).thenReturn(realms);
+        lenient().when(session.users()).thenReturn(users);
+        lenient().when(realms.getRealm(REALM_ID)).thenReturn(realm);
+        lenient().when(users.getUserById(realm, USER_ID)).thenReturn(user);
+        lenient().when(user.credentialManager()).thenReturn(credentials);
+        lenient().when(realm.getName()).thenReturn("test-realm");
+
+        provider = new RecoveryCodesCleanupEventListenerProvider(session);
+    }
+
+    private void stubOtp(CredentialModel... models) {
+        when(credentials.getStoredCredentialsByTypeStream(OTPCredentialModel.TYPE))
+                .thenReturn(Stream.of(models));
+    }
+
+    private void stubRecoveryCodes(CredentialModel... models) {
+        when(credentials.getStoredCredentialsByTypeStream(RecoveryAuthnCodesCredentialModel.TYPE))
+                .thenReturn(Stream.of(models));
+    }
+
+    private static CredentialModel credential(String id) {
+        CredentialModel model = mock(CredentialModel.class);
+        lenient().when(model.getId()).thenReturn(id);
+        return model;
+    }
+
+    private static Event removeTotpEvent() {
+        Event event = mock(Event.class);
+        when(event.getType()).thenReturn(EventType.REMOVE_TOTP);
+        lenient().when(event.getRealmId()).thenReturn(REALM_ID);
+        lenient().when(event.getUserId()).thenReturn(USER_ID);
+        return event;
+    }
+
+    @Test
+    void deletesRecoveryCodesWhenLastOtpRemoved() {
+        stubOtp(); // no OTP left
+        stubRecoveryCodes(credential("rc-1"), credential("rc-2"));
+
+        provider.onEvent(removeTotpEvent());
+
+        verify(credentials).removeStoredCredentialById("rc-1");
+        verify(credentials).removeStoredCredentialById("rc-2");
+    }
+
+    @Test
+    void keepsRecoveryCodesWhenOtpStillRemains() {
+        stubOtp(credential("otp-1")); // another OTP device remains
+
+        provider.onEvent(removeTotpEvent());
+
+        verify(credentials, never()).removeStoredCredentialById(org.mockito.ArgumentMatchers.anyString());
+        // Recovery codes are never even queried when OTP remains.
+        verify(credentials, never()).getStoredCredentialsByTypeStream(RecoveryAuthnCodesCredentialModel.TYPE);
+    }
+
+    @Test
+    void noopWhenNoRecoveryCodesExist() {
+        stubOtp(); // no OTP left
+        stubRecoveryCodes(); // and no recovery codes to clean up
+
+        provider.onEvent(removeTotpEvent());
+
+        verify(credentials, never()).removeStoredCredentialById(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void ignoresUnrelatedUserEvents() {
+        Event event = mock(Event.class);
+        when(event.getType()).thenReturn(EventType.LOGIN);
+
+        provider.onEvent(event);
+
+        // Never resolves the realm/user for events other than REMOVE_TOTP.
+        verify(session, never()).realms();
+        verify(session, never()).users();
+    }
+}

--- a/admin/src/test/java/org/tidepool/keycloak/extensions/events/TrustedDeviceCleanupEventListenerProviderTest.java
+++ b/admin/src/test/java/org/tidepool/keycloak/extensions/events/TrustedDeviceCleanupEventListenerProviderTest.java
@@ -1,0 +1,103 @@
+package org.tidepool.keycloak.extensions.events;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RealmProvider;
+import org.keycloak.models.SubjectCredentialManager;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
+
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TrustedDeviceCleanupEventListenerProviderTest {
+
+    private static final String REALM_ID = "realm-1";
+    private static final String USER_ID = "user-1";
+    private static final String TRUSTED_DEVICE_TYPE =
+            TrustedDeviceCleanupEventListenerProvider.TRUSTED_DEVICE_CREDENTIAL_TYPE;
+
+    private KeycloakSession session;
+    private SubjectCredentialManager credentials;
+    private TrustedDeviceCleanupEventListenerProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        session = mock(KeycloakSession.class);
+        RealmProvider realms = mock(RealmProvider.class);
+        UserProvider users = mock(UserProvider.class);
+        RealmModel realm = mock(RealmModel.class);
+        UserModel user = mock(UserModel.class);
+        credentials = mock(SubjectCredentialManager.class);
+
+        lenient().when(session.realms()).thenReturn(realms);
+        lenient().when(session.users()).thenReturn(users);
+        lenient().when(realms.getRealm(REALM_ID)).thenReturn(realm);
+        lenient().when(users.getUserById(realm, USER_ID)).thenReturn(user);
+        lenient().when(user.credentialManager()).thenReturn(credentials);
+        lenient().when(realm.getName()).thenReturn("test-realm");
+
+        provider = new TrustedDeviceCleanupEventListenerProvider(session);
+    }
+
+    private void stubTrustedDevices(CredentialModel... models) {
+        when(credentials.getStoredCredentialsByTypeStream(TRUSTED_DEVICE_TYPE))
+                .thenReturn(Stream.of(models));
+    }
+
+    private static CredentialModel credential(String id) {
+        CredentialModel model = mock(CredentialModel.class);
+        lenient().when(model.getId()).thenReturn(id);
+        return model;
+    }
+
+    private static Event updatePasswordEvent() {
+        Event event = mock(Event.class);
+        when(event.getType()).thenReturn(EventType.UPDATE_PASSWORD);
+        lenient().when(event.getRealmId()).thenReturn(REALM_ID);
+        lenient().when(event.getUserId()).thenReturn(USER_ID);
+        return event;
+    }
+
+    @Test
+    void removesAllTrustedDevicesOnPasswordChange() {
+        stubTrustedDevices(credential("td-1"), credential("td-2"));
+
+        provider.onEvent(updatePasswordEvent());
+
+        verify(credentials).removeStoredCredentialById("td-1");
+        verify(credentials).removeStoredCredentialById("td-2");
+    }
+
+    @Test
+    void noopWhenNoTrustedDevices() {
+        stubTrustedDevices(); // user has no trusted devices
+
+        provider.onEvent(updatePasswordEvent());
+
+        verify(credentials, never()).removeStoredCredentialById(anyString());
+    }
+
+    @Test
+    void ignoresUnrelatedUserEvents() {
+        Event event = mock(Event.class);
+        when(event.getType()).thenReturn(EventType.LOGIN);
+
+        provider.onEvent(event);
+
+        // Never resolves the realm/user for events other than UPDATE_PASSWORD.
+        verify(session, never()).realms();
+        verify(session, never()).users();
+    }
+}


### PR DESCRIPTION
Two event listeners with unit tests: delete recovery codes when the last OTP is removed, and remove trusted devices when the password changes.

---
📚 **Stacked PR 4 of 8.** Base branch: `tk-stack-3-aia-authenticator` — review/merge it first.

**Stack — review & merge bottom-up:**

1. `tk-stack-1-trusted-device-spi` → `master`
2. `tk-stack-2-attempted-username-fix` → `tk-stack-1-trusted-device-spi`
3. `tk-stack-3-aia-authenticator` → `tk-stack-2-attempted-username-fix`
4. `tk-stack-4-2fa-cleanup-listeners` → `tk-stack-3-aia-authenticator`
5. `tk-stack-5-login-activity-outbox` → `tk-stack-4-2fa-cleanup-listeners`
6. `tk-stack-6-email-changed-notification` → `tk-stack-5-login-activity-outbox`
7. `tk-stack-7-cancelable-email-change` → `tk-stack-6-email-changed-notification`
8. `tk-stack-8-theme-redesign` → `tk-stack-7-cancelable-email-change`

_Builds green on JDK 21 (`./mvnw clean compile package`); on the stack tip 42 admin + 35 home-idp tests pass._