### PR TITLE
[BACK-4442] Add user login-activity outbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN unset MAVEN_CONFIG && \
     ./mvnw versions:set -DnewVersion=LATEST -Drevision=LATEST && \
     ./mvnw install && \
     ./mvnw clean compile package && \
+    # The shade plugin leaves a pre-shade "original-admin-*.jar" alongside the shaded jar. Shipping both
+    # puts our resources on the classpath twice; Keycloak/Liquibase aborts startup on a duplicate
+    # changelog (META-INF/tidepool-user-activity-changelog.xml). Keep only the shaded jar.
+    rm -f admin/target/original-*.jar && \
     wget -O keycloak-rest-provider.jar https://github.com/daniel-frak/keycloak-user-migration/releases/download/6.2.1/keycloak-rest-provider-6.2.1.jar && \
     wget -O keycloak-metrics-spi.jar https://github.com/aerogear/keycloak-metrics-spi/releases/download/7.0.0/keycloak-metrics-spi-7.0.0.jar
 

--- a/admin/README.md
+++ b/admin/README.md
@@ -5,3 +5,14 @@ Additional admin endpoints for user administration
 ## Deployment
 
 Copy the jar from the target directory to `$KEYCLOAK_HOME/standalone/deployments`
+
+## User-activity outbox (CDC)
+
+A global event listener (`tidepool-user-activity`) writes a compact stream of user-activity facts —
+**last login**, **MFA enabled/disabled**, and **identity-provider links changed** — to the
+`TIDEPOOL_USER_ACTIVITY_EVENT` table so an external system can consume them via a CDC connector (e.g.
+Debezium). It uses the transactional-outbox pattern: each row commits in the same transaction as the
+Keycloak action that produced it, and the table is created, migrated, and pruned automatically.
+
+See **[docs/user-activity-outbox.md](docs/user-activity-outbox.md)** for the full event schema, event
+types and payloads, triggers, retention, configuration, and CDC consumption guidance.

--- a/admin/docs/user-activity-outbox.md
+++ b/admin/docs/user-activity-outbox.md
@@ -93,6 +93,12 @@ toward recording rather than losing a login.
 
 "Last login" for a user is the most recent `LOGIN` row for that `USER_ID`.
 
+Alongside each recorded `LOGIN` row, the listener also sets the user profile attribute
+**`last_login_time`** (epoch milliseconds, same value as the row's `EVENT_TIME`) in the same
+transaction. The outbox is pruned, so the attribute is the durable "last login" record — external
+systems can read it through the user model (e.g. shoreline's get-user endpoint) to backfill state
+for users with no recent outbox rows.
+
 ### `MFA_ENABLED` / `MFA_DISABLED`
 
 Emitted when a credential change **toggles** whether the user holds any second-factor credential
@@ -158,14 +164,16 @@ Both self-service (end-user) and admin-initiated changes are captured.
 | Outbox row          | Self-service (user events)                              | Admin (admin events, by resource path)                              |
 |---------------------|--------------------------------------------------------|---------------------------------------------------------------------|
 | `LOGIN`             | `LOGIN` — only when it creates a new session (SSO/cookie re-logins are skipped) | — (login has no admin equivalent)        |
-| `MFA_ENABLED`       | `UPDATE_CREDENTIAL`, `UPDATE_TOTP` (second-factor added) | — (admins cannot enrol a second factor for a user)                |
-| `MFA_DISABLED`      | `REMOVE_CREDENTIAL`, `REMOVE_TOTP` (last second factor removed) | `DELETE users/{id}/credentials/...`, `users/{id}/disable-credential-types` |
+| `MFA_ENABLED`       | `UPDATE_CREDENTIAL` (second-factor added) | — (admins cannot enrol a second factor for a user)                |
+| `MFA_DISABLED`      | `REMOVE_CREDENTIAL` (last second factor removed) | `DELETE users/{id}/credentials/...`, `users/{id}/disable-credential-types` |
 | `IDP_LINKS_CHANGED` | `FEDERATED_IDENTITY_LINK`, `REMOVE_FEDERATED_IDENTITY`, `FEDERATED_IDENTITY_OVERRIDE_LINK` | `users/{id}/federated-identity/...`        |
 
 Failed operations (admin events carrying an error) are ignored. For MFA and IdP changes the listener
 recomputes state from the user model regardless of trigger, so admin and self-service paths produce
 identical, consistent rows. A non-`DELETE` operation on a credential (e.g. setting a label) is not
-treated as a removal.
+treated as a removal. The deprecated `UPDATE_TOTP`/`REMOVE_TOTP` events are deliberately ignored:
+Keycloak fires them as **extra duplicates alongside** the consolidated `UPDATE_CREDENTIAL`/
+`REMOVE_CREDENTIAL` events on every OTP change, so reacting to both would record each change twice.
 
 ## Backfilling existing IdP links
 

--- a/admin/docs/user-activity-outbox.md
+++ b/admin/docs/user-activity-outbox.md
@@ -77,7 +77,13 @@ payload column and is populated for `IDP_LINKS_CHANGED` rows only.
 
 ### `LOGIN`
 
-One row per successful browser login.
+One row per **user session** — i.e. per fresh interactive login. Keycloak fires a `LOGIN` event for
+cookie/SSO re-authentications too (every additional client the user reaches while already logged in),
+which would otherwise flood the table. The dedup is deterministic: the first `LOGIN` of a session
+records a row and sets a marker note on the `UserSession`; every later `LOGIN` reusing that session
+sees the note and is skipped. No time-window heuristics — slow required actions, SSO bursts, and clock
+skew cannot cause drops or duplicates. When the session cannot be resolved at all, the listener fails
+toward recording rather than losing a login.
 
 | Column               | Value                          |
 |----------------------|--------------------------------|
@@ -151,7 +157,7 @@ Both self-service (end-user) and admin-initiated changes are captured.
 
 | Outbox row          | Self-service (user events)                              | Admin (admin events, by resource path)                              |
 |---------------------|--------------------------------------------------------|---------------------------------------------------------------------|
-| `LOGIN`             | `LOGIN`                                                | — (login has no admin equivalent)                                   |
+| `LOGIN`             | `LOGIN` — only when it creates a new session (SSO/cookie re-logins are skipped) | — (login has no admin equivalent)        |
 | `MFA_ENABLED`       | `UPDATE_CREDENTIAL`, `UPDATE_TOTP` (second-factor added) | — (admins cannot enrol a second factor for a user)                |
 | `MFA_DISABLED`      | `REMOVE_CREDENTIAL`, `REMOVE_TOTP` (last second factor removed) | `DELETE users/{id}/credentials/...`, `users/{id}/disable-credential-types` |
 | `IDP_LINKS_CHANGED` | `FEDERATED_IDENTITY_LINK`, `REMOVE_FEDERATED_IDENTITY`, `FEDERATED_IDENTITY_OVERRIDE_LINK` | `users/{id}/federated-identity/...`        |
@@ -160,6 +166,30 @@ Failed operations (admin events carrying an error) are ignored. For MFA and IdP 
 recomputes state from the user model regardless of trigger, so admin and self-service paths produce
 identical, consistent rows. A non-`DELETE` operation on a credential (e.g. setting a label) is not
 treated as a removal.
+
+## Backfilling existing IdP links
+
+The listener only emits `IDP_LINKS_CHANGED` when a link changes *after* it's deployed, so users linked
+beforehand aren't represented. A one-off, admin-authenticated endpoint seeds them:
+
+```
+POST /realms/{realm}/tidepool-admin/backfill-idp-links
+Authorization: Bearer <admin token with manage-realm on {realm}>
+→ 200 {"realm":"<realm>","backfilled":<n>,"skipped":<n>,"failed":<n>}
+```
+
+It finds the users in the realm that currently have a federated link (Keycloak's `FEDERATED_IDENTITY`
+table), and writes one `IDP_LINKS_CHANGED` row per user with their current link set — using the **same
+code path** as live events, so the rows are identical. Permission (`manage-realm`) is checked against
+the **target** realm in the path.
+
+The work runs in **batches of 100, each in its own transaction**, so memory stays bounded on large
+realms and a failure only loses its own batch (`failed`, with the error logged) instead of rolling back
+the whole run. Users whose user record or links disappeared between enumeration and processing are
+counted in `skipped` (no empty `[]` rows are written). Run it once per realm after deploying. It is
+**idempotent**: re-running just re-records current state (consumers upsert). There is no login/MFA
+backfill (Keycloak does not retain that history); only IdP links can be reconstructed from current
+state.
 
 ## Retention & cleanup
 
@@ -230,6 +260,8 @@ Defined in the changelog and sized to the access patterns:
 |------|------|
 | `UserActivityEventEntity.java` | JPA entity + named queries for the outbox table. |
 | `UserActivityEventListenerProvider.java` (+ `Factory`) | Observes events, writes outbox rows, schedules cleanup. |
+| `UserActivityRecorder.java` | Shared row writer (IdP-links JSON + persist); used by the listener and the backfill. |
 | `UserActivityJpaEntityProvider.java` (+ `Factory`) | Registers the entity and its changelog with Keycloak's datasource. |
 | `UserActivityCleanupTask.java` | Age- and size-based pruning. |
 | `admin/src/main/resources/META-INF/tidepool-user-activity-changelog.xml` | Liquibase schema. |
+| `resource/TidepoolAdminResource.java` → `backfillIdpLinks()` | Admin endpoint that backfills `IDP_LINKS_CHANGED` for existing links. |

--- a/admin/docs/user-activity-outbox.md
+++ b/admin/docs/user-activity-outbox.md
@@ -1,0 +1,235 @@
+# User-activity outbox
+
+A Keycloak extension that publishes a compact, stable stream of user-activity facts — **last login**,
+**MFA enabled/disabled**, and **identity-provider links changed** — to a database table that an
+external system consumes via Change Data Capture (CDC), e.g. [Debezium](https://debezium.io/).
+
+- [Why a custom table](#why-a-custom-table)
+- [How it works](#how-it-works)
+- [Event schema](#event-schema)
+- [Event types](#event-types)
+  - [`LOGIN`](#login)
+  - [`MFA_ENABLED` / `MFA_DISABLED`](#mfa_enabled--mfa_disabled)
+  - [`IDP_LINKS_CHANGED`](#idp_links_changed)
+- [What triggers an event](#what-triggers-an-event)
+- [Retention & cleanup](#retention--cleanup)
+- [Configuration](#configuration)
+- [Consuming the table (CDC)](#consuming-the-table-cdc)
+- [Indexes](#indexes)
+- [Out of scope / caveats](#out-of-scope--caveats)
+- [Source](#source)
+
+## Why a custom table
+
+Keycloak already has a built-in event store (`EVENT_ENTITY`) with event-type filtering and time-based
+expiration, and you *could* point CDC at it. We don't, for three reasons:
+
+1. **"MFA enabled/disabled" is not an event Keycloak emits.** MFA is not a flag — it is "does the user
+   hold a second-factor credential". Deciding whether 2FA is now on or off requires inspecting the
+   user's remaining credentials at event time, which only in-process code can do.
+2. **`EVENT_ENTITY` is a generic, Keycloak-owned schema** (details live in a `DETAILS_JSON` blob, and
+   the schema can change across upgrades). Coupling an external contract to it is brittle.
+3. **Cleanup must be size-bounded too**, which the built-in time-only expiration does not offer.
+
+So this extension writes a purpose-built table with a flat schema it owns, holding only the handful of
+facts we publish.
+
+## How it works
+
+This is the [transactional-outbox](https://microservices.io/patterns/data/transactional-outbox.html)
+pattern.
+
+- A **global event listener** (provider id `tidepool-user-activity`) observes Keycloak user and admin
+  events and writes one row per fact into `TIDEPOOL_USER_ACTIVITY_EVENT`.
+- Rows are written through the request's **shared JPA session**, so each row commits in the **same
+  transaction** as the Keycloak action that produced it. There is no separate publish step that could
+  drift from the source change.
+- The table is **created and migrated automatically** via a Keycloak JPA entity provider (Liquibase
+  changelog); no manual SQL or DDL is required.
+- A **cluster-aware timer** prunes the table by age and size (see [Retention & cleanup](#retention--cleanup)).
+- An external **CDC connector** streams inserts out of the table to the downstream system.
+
+```
+Keycloak action ──fires──> event listener ──persist (same txn)──> TIDEPOOL_USER_ACTIVITY_EVENT
+                                                                          │
+                                                   CDC connector (Debezium) reads inserts
+                                                                          │
+                                                                  external system
+```
+
+## Event schema
+
+Table: **`TIDEPOOL_USER_ACTIVITY_EVENT`**
+
+| Column               | Type           | Null? | Description                                                                                 |
+|----------------------|----------------|-------|---------------------------------------------------------------------------------------------|
+| `ID`                 | `VARCHAR(36)`  | no    | Primary key (UUID).                                                                          |
+| `REALM_ID`           | `VARCHAR(255)` | no    | Realm the user belongs to.                                                                  |
+| `USER_ID`            | `VARCHAR(255)` | no    | Keycloak user id.                                                                            |
+| `EVENT_TYPE`         | `VARCHAR(32)`  | no    | One of `LOGIN`, `MFA_ENABLED`, `MFA_DISABLED`, `IDP_LINKS_CHANGED`. This **is** the fact — MFA on/off is read straight from `MFA_ENABLED` vs `MFA_DISABLED`. |
+| `IDENTITY_PROVIDERS` | `VARCHAR(4000)`| yes   | JSON array of linked IdPs for `IDP_LINKS_CHANGED` rows; `null` otherwise.                    |
+| `EVENT_TIME`         | `BIGINT`       | no    | Epoch **milliseconds** the source event occurred. Drives ordering and pruning.              |
+
+Every row carries `REALM_ID`, `USER_ID`, `EVENT_TYPE`, and `EVENT_TIME`. `IDENTITY_PROVIDERS` is the only
+payload column and is populated for `IDP_LINKS_CHANGED` rows only.
+
+## Event types
+
+### `LOGIN`
+
+One row per successful browser login.
+
+| Column               | Value                          |
+|----------------------|--------------------------------|
+| `EVENT_TYPE`         | `LOGIN`                        |
+| `EVENT_TIME`         | Login time (epoch ms)          |
+| `IDENTITY_PROVIDERS` | `null`                         |
+
+"Last login" for a user is the most recent `LOGIN` row for that `USER_ID`.
+
+### `MFA_ENABLED` / `MFA_DISABLED`
+
+Emitted when a credential change **toggles** whether the user holds any second-factor credential
+(OTP, WebAuthn, or WebAuthn passwordless). The **direction comes from the event itself, not from stored
+history** — the outbox is pruned, so it can't be its own source of truth:
+
+- An **add/update** of a second-factor credential records `MFA_ENABLED`, as long as the user has a second
+  factor afterwards.
+- A **removal** of a second-factor credential records `MFA_DISABLED`, but **only once no second factor
+  remains**.
+
+On either kind of event the listener recomputes the user's current credentials, so the row always states
+the user's **true current state** — it is therefore safe for the consumer to upsert and ignore repeats.
+When the changed credential's type is known and is not a second factor (e.g. a password), the listener
+short-circuits without even loading the user.
+
+| Column               | Value                                            |
+|----------------------|--------------------------------------------------|
+| `EVENT_TYPE`         | `MFA_ENABLED` or `MFA_DISABLED`                  |
+| `EVENT_TIME`         | Time of the credential change (epoch ms)         |
+| `IDENTITY_PROVIDERS` | `null`                                           |
+
+This means:
+
+- Enrolling a **first** authenticator → `MFA_ENABLED`.
+- Adding a **second** authenticator → `MFA_ENABLED` again (a redundant "still on"; the consumer upserts).
+- Removing **one of two** authenticators → **no row** (a second factor still remains).
+- Removing the **last** authenticator → `MFA_DISABLED`.
+- Changing or removing a password → **no row** (not a second factor).
+
+### `IDP_LINKS_CHANGED`
+
+Emitted whenever an identity-provider link is added or removed. The payload is the user's **full**
+current set of linked IdPs (not just the one that changed), so the external system can replace its view
+wholesale.
+
+`IDENTITY_PROVIDERS` is a JSON array sorted by `alias`:
+
+```json
+[
+  {"alias": "google", "name": "Google"},
+  {"alias": "azure-ad", "name": "Corporate Azure AD"}
+]
+```
+
+- `alias` — the IdP's unique alias in the realm.
+- `name` — the IdP's configured **display name**; when it has none, a human-readable name derived from
+  the alias (non-alphanumeric separators become spaces and each word is capitalized, e.g.
+  `google-tidepool` → `Google Tidepool`). Always present.
+
+When the user's **last** link is removed, the array is empty: `[]`.
+
+| Column               | Value                              |
+|----------------------|------------------------------------|
+| `EVENT_TYPE`         | `IDP_LINKS_CHANGED`                |
+| `IDENTITY_PROVIDERS` | JSON array as above (`[]` if none) |
+| `EVENT_TIME`         | Time of the link change (epoch ms) |
+
+## What triggers an event
+
+Both self-service (end-user) and admin-initiated changes are captured.
+
+| Outbox row          | Self-service (user events)                              | Admin (admin events, by resource path)                              |
+|---------------------|--------------------------------------------------------|---------------------------------------------------------------------|
+| `LOGIN`             | `LOGIN`                                                | — (login has no admin equivalent)                                   |
+| `MFA_ENABLED`       | `UPDATE_CREDENTIAL`, `UPDATE_TOTP` (second-factor added) | — (admins cannot enrol a second factor for a user)                |
+| `MFA_DISABLED`      | `REMOVE_CREDENTIAL`, `REMOVE_TOTP` (last second factor removed) | `DELETE users/{id}/credentials/...`, `users/{id}/disable-credential-types` |
+| `IDP_LINKS_CHANGED` | `FEDERATED_IDENTITY_LINK`, `REMOVE_FEDERATED_IDENTITY`, `FEDERATED_IDENTITY_OVERRIDE_LINK` | `users/{id}/federated-identity/...`        |
+
+Failed operations (admin events carrying an error) are ignored. For MFA and IdP changes the listener
+recomputes state from the user model regardless of trigger, so admin and self-service paths produce
+identical, consistent rows. A non-`DELETE` operation on a credential (e.g. setting a label) is not
+treated as a removal.
+
+## Retention & cleanup
+
+The table is insert-only from the extension's side and is pruned by a **cluster-aware scheduled task**
+(only one node prunes per interval). Two bounds are applied each sweep:
+
+1. **Age** — rows older than the retention window are deleted (default: one week); disabled when
+   `retention-hours <= 0`.
+2. **Size** — when enabled, the oldest rows are trimmed so at most `max-rows` remain. This is a *soft*
+   cap: ties at the boundary millisecond may leave the table slightly under the cap, never over. The
+   boundary timestamp is found by scanning only the overflow rows (oldest-first, offset by the overflow
+   count), not the whole retained set, so the trim stays cheap even at a large `max-rows`.
+
+Because pruning issues `DELETE`s, the CDC consumer should **ignore deletes** — the outbox is
+insert-driven and deletes are cleanup only.
+
+## Configuration
+
+Set as Keycloak SPI options (CLI flags, `keycloak.conf`, or `KC_SPI_*` env vars). Defaults shown:
+
+```
+spi-events-listener-tidepool-user-activity-retention-hours=168          # age cutoff (1 week); <= 0 disables age pruning
+spi-events-listener-tidepool-user-activity-max-rows=5000000             # size cap; <= 0 disables it
+spi-events-listener-tidepool-user-activity-cleanup-interval-minutes=60  # prune frequency
+```
+
+Setting `retention-hours` to `0` or a negative value **disables** age-based pruning (it does not collapse
+the cutoff to "now"); disable both bounds only if you prune the table by some other means.
+
+The listener is **global** — it runs for every realm with no per-realm "events listeners"
+configuration required.
+
+## Consuming the table (CDC)
+
+- **Log-based CDC (recommended)** — point Debezium at `TIDEPOOL_USER_ACTIVITY_EVENT`. No extra schema
+  is needed; the `ID` primary key covers Postgres `REPLICA IDENTITY` and connector keying. Filter to
+  insert (`c`) events and ignore deletes.
+- **Derived state in the downstream system:**
+  - *Last login* = latest `EVENT_TIME` among `LOGIN` rows per `USER_ID`.
+  - *MFA enabled?* = whether the latest `MFA_*` row per `USER_ID` is `MFA_ENABLED` (vs `MFA_DISABLED`).
+  - *Linked IdPs* = `IDENTITY_PROVIDERS` of the latest `IDP_LINKS_CHANGED` row per `USER_ID`.
+- Rows are independent and idempotent to re-process; ordering within a user is by `EVENT_TIME`.
+
+## Indexes
+
+Defined in the changelog and sized to the access patterns:
+
+| Index                       | Columns                            | Serves                                                |
+|-----------------------------|------------------------------------|-------------------------------------------------------|
+| `PK_TIDEPOOL_USER_ACTIVITY_EVENT` | `ID`                         | Primary key / CDC keying.                             |
+| `IDX_TP_ACTIVITY_USER_TIME` | `(REALM_ID, USER_ID, EVENT_TIME)`  | Operational "activity for a user" queries. The listener no longer reads it. |
+| `IDX_TP_ACTIVITY_TIME`      | `(EVENT_TIME)`                     | Age- and size-based pruning, ordered scans.           |
+
+## Out of scope / caveats
+
+- **No "MFA setup" admin event.** Admins cannot enrol a second factor *for* a user (that goes through a
+  required action the user completes, which arrives as a self-service event). Admin-side MFA changes are
+  therefore disablements (credential removal / `disable-credential-types`).
+- **`EVENT_TIME` is milliseconds**, taken from the source Keycloak event.
+- **Deletes are cleanup.** Anything the consumer must retain should be projected into downstream storage;
+  the outbox is not a durable archive.
+
+## Source
+
+`admin/src/main/java/org/tidepool/keycloak/extensions/activity/`
+
+| File | Role |
+|------|------|
+| `UserActivityEventEntity.java` | JPA entity + named queries for the outbox table. |
+| `UserActivityEventListenerProvider.java` (+ `Factory`) | Observes events, writes outbox rows, schedules cleanup. |
+| `UserActivityJpaEntityProvider.java` (+ `Factory`) | Registers the entity and its changelog with Keycloak's datasource. |
+| `UserActivityCleanupTask.java` | Age- and size-based pruning. |
+| `admin/src/main/resources/META-INF/tidepool-user-activity-changelog.xml` | Liquibase schema. |

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -58,6 +58,26 @@
             <version>${keycloak.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- JpaConnectionProvider / JpaEntityProvider for the user-activity outbox table -->
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-model-jpa</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- ClusterAwareScheduledTaskRunner for cluster-safe outbox pruning -->
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-model-storage-private</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityCleanupTask.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityCleanupTask.java
@@ -1,0 +1,98 @@
+package org.tidepool.keycloak.extensions.activity;
+
+import jakarta.persistence.EntityManager;
+import org.jboss.logging.Logger;
+import org.keycloak.common.util.Time;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.timer.ScheduledTask;
+
+import java.util.List;
+
+/**
+ * Prunes the {@link UserActivityEventEntity} outbox so it cannot grow without bound. Runs on a timer
+ * (cluster-aware, so a single node prunes per interval) and applies two bounds:
+ *
+ * <ol>
+ *   <li><b>Age</b> &mdash; deletes rows older than the retention window (default one week); disabled
+ *       when {@code retentionMillis <= 0}.</li>
+ *   <li><b>Size</b> &mdash; when enabled, trims the oldest rows so at most {@code maxRows} remain.</li>
+ * </ol>
+ *
+ * <p>The size trim is a soft cap: it deletes at or below the boundary timestamp, so ties at the
+ * boundary millisecond may leave the table slightly under {@code maxRows}, never over. The boundary is
+ * located by scanning only the rows to be dropped (oldest-first, offset by the overflow count), not the
+ * whole retained set.
+ */
+public class UserActivityCleanupTask implements ScheduledTask {
+
+    private static final Logger LOG = Logger.getLogger(UserActivityCleanupTask.class);
+
+    private final long retentionMillis;
+    private final long maxRows;
+
+    /**
+     * @param retentionMillis age threshold; rows older than this are deleted, or {@code <= 0} to
+     *                        disable age-based pruning.
+     * @param maxRows         maximum rows to retain, or {@code <= 0} to disable the size cap.
+     */
+    public UserActivityCleanupTask(long retentionMillis, long maxRows) {
+        this.retentionMillis = retentionMillis;
+        this.maxRows = maxRows;
+    }
+
+    // The EntityManager is owned and closed by the Keycloak session/transaction; we must not close it.
+    @SuppressWarnings("resource")
+    @Override
+    public void run(KeycloakSession session) {
+        EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+
+        int byAge = pruneByAge(em);
+        int bySize = trimToMaxRows(em);
+
+        if (byAge + bySize > 0) {
+            LOG.infof("Pruned user-activity outbox: %d row(s) by age, %d row(s) by size", byAge, bySize);
+        }
+    }
+
+    private int pruneByAge(EntityManager em) {
+        if (retentionMillis <= 0) {
+            return 0; // Age-based pruning disabled.
+        }
+        long cutoff = Time.currentTimeMillis() - retentionMillis;
+        return em.createNamedQuery("TidepoolUserActivityEvent.deleteOlderThan")
+                .setParameter("cutoff", cutoff)
+                .executeUpdate();
+    }
+
+    private int trimToMaxRows(EntityManager em) {
+        if (maxRows <= 0) {
+            return 0;
+        }
+
+        long count = em.createNamedQuery("TidepoolUserActivityEvent.count", Long.class).getSingleResult();
+        long excess = count - maxRows;
+        if (excess <= 0) {
+            return 0;
+        }
+
+        // Boundary = the newest event time among the `excess` oldest rows. Scanning oldest-first and
+        // offsetting by (excess - 1) touches only the rows we intend to drop, not all maxRows kept.
+        List<Long> boundary = em.createNamedQuery("TidepoolUserActivityEvent.eventTimesAsc", Long.class)
+                .setFirstResult((int) Math.min(excess - 1, Integer.MAX_VALUE))
+                .setMaxResults(1)
+                .getResultList();
+        if (boundary.isEmpty()) {
+            return 0;
+        }
+
+        return em.createNamedQuery("TidepoolUserActivityEvent.deleteAtOrOlderThan")
+                .setParameter("threshold", boundary.get(0))
+                .executeUpdate();
+    }
+
+    @Override
+    public String getTaskName() {
+        return UserActivityEventListenerProviderFactory.CLEANUP_TASK_NAME;
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventEntity.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventEntity.java
@@ -1,0 +1,141 @@
+package org.tidepool.keycloak.extensions.activity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+
+/**
+ * Outbox row recording a user-activity change worth propagating to an external system via CDC.
+ *
+ * <p>This is a purpose-built outbox table rather than Keycloak's generic {@code EVENT_ENTITY} store:
+ * it carries a flat, stable schema for the CDC connector, holds <em>only</em> the handful of facts we
+ * want to publish, and is owned (and pruned) by this extension. Rows are written in the same
+ * transaction as the Keycloak action that produced them (the transactional-outbox pattern), and are
+ * pruned by {@link UserActivityCleanupTask}.
+ *
+ * <p>Each row is one of:
+ * <ul>
+ *   <li>{@code LOGIN} &mdash; a successful browser login; {@link #eventTime} is the login time.</li>
+ *   <li>{@code MFA_ENABLED} / {@code MFA_DISABLED} &mdash; the user gained, or no longer has, a
+ *       two-factor credential. The {@link #eventType} is the state; there is no separate flag.</li>
+ *   <li>{@code IDP_LINKS_CHANGED} &mdash; an identity-provider link was added or removed;
+ *       {@link #identityProviders} carries the user's full set of linked IdPs afterwards, as JSON.</li>
+ * </ul>
+ */
+@Entity
+@Table(name = "TIDEPOOL_USER_ACTIVITY_EVENT")
+@NamedQueries({
+        // Time-based pruning: drop everything strictly older than the retention cutoff.
+        @NamedQuery(name = "TidepoolUserActivityEvent.deleteOlderThan",
+                query = "DELETE FROM UserActivityEventEntity e WHERE e.eventTime < :cutoff"),
+        // Size-based pruning: drop everything at or older than a boundary timestamp.
+        @NamedQuery(name = "TidepoolUserActivityEvent.deleteAtOrOlderThan",
+                query = "DELETE FROM UserActivityEventEntity e WHERE e.eventTime <= :threshold"),
+        @NamedQuery(name = "TidepoolUserActivityEvent.count",
+                query = "SELECT COUNT(e) FROM UserActivityEventEntity e"),
+        // Event times oldest-first; used with setFirstResult(excess - 1) to find the size-based boundary
+        // by scanning only the rows to be dropped, not the whole retained set.
+        @NamedQuery(name = "TidepoolUserActivityEvent.eventTimesAsc",
+                query = "SELECT e.eventTime FROM UserActivityEventEntity e ORDER BY e.eventTime ASC")
+})
+public class UserActivityEventEntity {
+
+    public static final String TYPE_LOGIN = "LOGIN";
+    public static final String TYPE_MFA_ENABLED = "MFA_ENABLED";
+    public static final String TYPE_MFA_DISABLED = "MFA_DISABLED";
+    public static final String TYPE_IDP_LINKS_CHANGED = "IDP_LINKS_CHANGED";
+
+    @Id
+    @Column(name = "ID", length = 36)
+    private String id;
+
+    @Column(name = "REALM_ID", nullable = false)
+    private String realmId;
+
+    @Column(name = "USER_ID", nullable = false)
+    private String userId;
+
+    @Column(name = "EVENT_TYPE", nullable = false, length = 32)
+    private String eventType;
+
+    /**
+     * For {@code IDP_LINKS_CHANGED} rows, a JSON array of the IdPs the user is linked to, sorted by
+     * alias, e.g. {@code [{"alias":"google","name":"Google"}]} (where {@code name} is the provider's
+     * display name, or a humanized alias when it has none); an empty array {@code []} when the last
+     * link was removed. {@code null} for other event types.
+     *
+     * <p>Sized at the portable {@code VARCHAR} maximum (4000) so realistic link sets never overflow:
+     * because the row is written in the source transaction, a length violation would roll back the
+     * triggering action, not just the outbox write.
+     */
+    @Column(name = "IDENTITY_PROVIDERS", length = 4000)
+    private String identityProviders;
+
+    /** Epoch milliseconds the source event occurred; drives both ordering and pruning. */
+    @Column(name = "EVENT_TIME", nullable = false)
+    private long eventTime;
+
+    public UserActivityEventEntity() {
+    }
+
+    public UserActivityEventEntity(String id, String realmId, String userId, String eventType,
+                                   String identityProviders, long eventTime) {
+        this.id = id;
+        this.realmId = realmId;
+        this.userId = userId;
+        this.eventType = eventType;
+        this.identityProviders = identityProviders;
+        this.eventTime = eventTime;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getRealmId() {
+        return realmId;
+    }
+
+    public void setRealmId(String realmId) {
+        this.realmId = realmId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getIdentityProviders() {
+        return identityProviders;
+    }
+
+    public void setIdentityProviders(String identityProviders) {
+        this.identityProviders = identityProviders;
+    }
+
+    public long getEventTime() {
+        return eventTime;
+    }
+
+    public void setEventTime(long eventTime) {
+        this.eventTime = eventTime;
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProvider.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProvider.java
@@ -45,13 +45,18 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
 
     private static final Logger LOG = Logger.getLogger(UserActivityEventListenerProvider.class);
 
-    /** Credential additions/updates: while the user has a second factor, record MFA as enabled. */
-    private static final Set<EventType> CREDENTIAL_ADDED_EVENTS = EnumSet.of(
-            EventType.UPDATE_CREDENTIAL, EventType.UPDATE_TOTP);
+    /**
+     * Credential additions/updates: while the user has a second factor, record MFA as enabled.
+     *
+     * <p>Deliberately excludes the deprecated {@link EventType#UPDATE_TOTP}/{@link EventType#REMOVE_TOTP}:
+     * Keycloak fires those as <em>extra duplicates alongside</em> the consolidated
+     * {@code UPDATE_CREDENTIAL}/{@code REMOVE_CREDENTIAL} events on every OTP change (it clones the
+     * event builder and emits both), so listening to both records every OTP change twice.
+     */
+    private static final Set<EventType> CREDENTIAL_ADDED_EVENTS = EnumSet.of(EventType.UPDATE_CREDENTIAL);
 
-    /** Credential removals: once no second factor remains, record MFA as disabled. */
-    private static final Set<EventType> CREDENTIAL_REMOVED_EVENTS = EnumSet.of(
-            EventType.REMOVE_CREDENTIAL, EventType.REMOVE_TOTP);
+    /** Credential removals: once no second factor remains, record MFA as disabled. See note above. */
+    private static final Set<EventType> CREDENTIAL_REMOVED_EVENTS = EnumSet.of(EventType.REMOVE_CREDENTIAL);
 
     /** Federated-identity changes after which we re-publish the user's full IdP link set. */
     private static final Set<EventType> IDP_LINK_EVENTS = EnumSet.of(
@@ -66,6 +71,14 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
      * SSO bursts, and clock skew).
      */
     static final String LOGIN_RECORDED_NOTE = "tidepool-user-activity-login-recorded";
+
+    /**
+     * User profile attribute updated alongside each recorded LOGIN row. The outbox is pruned, so the
+     * attribute is the durable "last login" record; external systems read it through the user model
+     * (e.g. shoreline's get-user endpoint) to backfill state for users with no recent outbox rows.
+     * Epoch milliseconds, same clock and format as the outbox {@code EVENT_TIME}.
+     */
+    static final String LAST_LOGIN_TIME_ATTRIBUTE = "last_login_time";
 
     /** Credential types that count as a second factor for the MFA-enabled determination. */
     private static final Set<String> MFA_CREDENTIAL_TYPES = Set.of(
@@ -150,9 +163,27 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
             return; // Already recorded for this session — a cookie/SSO re-login for another client.
         }
         recorder.recordLogin(realmId, userId, time);
+        updateLastLoginAttribute(realmId, userId, time);
         if (userSession != null) {
             userSession.setNote(LOGIN_RECORDED_NOTE, "true");
         }
+    }
+
+    /**
+     * Mirrors the recorded login time onto the user's {@link #LAST_LOGIN_TIME_ATTRIBUTE} profile
+     * attribute, committing in the same transaction as the outbox row. Skipped silently when the
+     * realm or user cannot be resolved — the outbox row is still recorded.
+     */
+    private void updateLastLoginAttribute(String realmId, String userId, long time) {
+        RealmModel realm = resolveRealm(realmId);
+        if (realm == null) {
+            return;
+        }
+        UserModel user = session.users().getUserById(realm, userId);
+        if (user == null) {
+            return;
+        }
+        user.setSingleAttribute(LAST_LOGIN_TIME_ATTRIBUTE, Long.toString(time));
     }
 
     private UserSessionModel lookupUserSession(String realmId, String sessionId) {

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProvider.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProvider.java
@@ -1,0 +1,287 @@
+package org.tidepool.keycloak.extensions.activity;
+
+import jakarta.persistence.EntityManager;
+import org.jboss.logging.Logger;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.events.Details;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventType;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderStorageProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.SubjectCredentialManager;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.credential.OTPCredentialModel;
+import org.keycloak.models.credential.WebAuthnCredentialModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Writes a compact stream of user-activity facts into the {@link UserActivityEventEntity} outbox so an
+ * external system can consume them via CDC. It records exactly three things, and nothing else:
+ *
+ * <ul>
+ *   <li><b>Last login</b> &mdash; one row per successful {@link EventType#LOGIN}.</li>
+ *   <li><b>MFA enabled/disabled</b> &mdash; the direction comes from the event itself, not from stored
+ *       history (the outbox is pruned, so it cannot be its own source of truth). Adding/updating a
+ *       second-factor credential records {@code MFA_ENABLED} while the user has one; removing a
+ *       second-factor credential records {@code MFA_DISABLED} only once none remain. Either row always
+ *       states the user's true current state, so it is safe for the consumer to upsert and ignore
+ *       repeats. Non-second-factor credential changes (e.g. passwords) produce no row.</li>
+ *   <li><b>IdP links changed</b> &mdash; on a federated-identity link or unlink, it records the user's
+ *       full current set of linked identity-provider aliases.</li>
+ * </ul>
+ *
+ * <p>Rows are persisted through the request's shared JPA session, so they commit atomically with the
+ * Keycloak action that triggered them (the transactional-outbox pattern).
+ *
+ * <p>Both self-service (user) and admin-initiated changes are captured: the latter arrive as
+ * {@link AdminEvent}s whose {@link AdminEvent#getResourcePath() resource path} identifies the affected
+ * user and the kind of change. Login is inherently a user event and has no admin equivalent.
+ */
+public class UserActivityEventListenerProvider implements EventListenerProvider {
+
+    private static final Logger LOG = Logger.getLogger(UserActivityEventListenerProvider.class);
+
+    /** Credential additions/updates: while the user has a second factor, record MFA as enabled. */
+    private static final Set<EventType> CREDENTIAL_ADDED_EVENTS = EnumSet.of(
+            EventType.UPDATE_CREDENTIAL, EventType.UPDATE_TOTP);
+
+    /** Credential removals: once no second factor remains, record MFA as disabled. */
+    private static final Set<EventType> CREDENTIAL_REMOVED_EVENTS = EnumSet.of(
+            EventType.REMOVE_CREDENTIAL, EventType.REMOVE_TOTP);
+
+    /** Federated-identity changes after which we re-publish the user's full IdP link set. */
+    private static final Set<EventType> IDP_LINK_EVENTS = EnumSet.of(
+            EventType.FEDERATED_IDENTITY_LINK, EventType.REMOVE_FEDERATED_IDENTITY,
+            EventType.FEDERATED_IDENTITY_OVERRIDE_LINK);
+
+    /** Credential types that count as a second factor for the MFA-enabled determination. */
+    private static final Set<String> MFA_CREDENTIAL_TYPES = Set.of(
+            OTPCredentialModel.TYPE,
+            WebAuthnCredentialModel.TYPE_TWOFACTOR,
+            WebAuthnCredentialModel.TYPE_PASSWORDLESS);
+
+    // Admin resource-path categories ({@code users/{id}/<category>/...}).
+    private static final String FEDERATED_IDENTITY_PATH_SEGMENT = "federated-identity";
+    private static final String CREDENTIALS_PATH_SEGMENT = "credentials";
+    private static final String DISABLE_CREDENTIAL_TYPES_PATH_SEGMENT = "disable-credential-types";
+
+    private final KeycloakSession session;
+
+    public UserActivityEventListenerProvider(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        EventType type = event.getType();
+        if (type == EventType.LOGIN) {
+            recordLogin(event.getRealmId(), event.getUserId(), event.getTime());
+        } else if (CREDENTIAL_ADDED_EVENTS.contains(type)) {
+            recordMfaCredentialChange(event.getRealmId(), event.getUserId(), event.getTime(),
+                    credentialType(event), false);
+        } else if (CREDENTIAL_REMOVED_EVENTS.contains(type)) {
+            recordMfaCredentialChange(event.getRealmId(), event.getUserId(), event.getTime(),
+                    credentialType(event), true);
+        } else if (IDP_LINK_EVENTS.contains(type)) {
+            recordIdpLinks(event.getRealmId(), event.getUserId(), event.getTime());
+        }
+    }
+
+    private static String credentialType(Event event) {
+        return event.getDetails() == null ? null : event.getDetails().get(Details.CREDENTIAL_TYPE);
+    }
+
+    @Override
+    public void onEvent(AdminEvent event, boolean includeRepresentation) {
+        if (event.getError() != null) {
+            return; // Only successful operations.
+        }
+
+        // Resource path mirrors the admin REST URI: users/{userId}/{category}/...
+        String path = event.getResourcePath();
+        if (path == null) {
+            return;
+        }
+        String[] segments = path.split("/");
+        if (segments.length < 3 || !"users".equals(segments[0])) {
+            return;
+        }
+
+        String realmId = event.getRealmId(); // The administered realm (where the user lives).
+        String userId = segments[1];
+        String category = segments[2];
+        if (FEDERATED_IDENTITY_PATH_SEGMENT.equals(category)) {
+            recordIdpLinks(realmId, userId, event.getTime());
+        } else if (DISABLE_CREDENTIAL_TYPES_PATH_SEGMENT.equals(category)) {
+            // Admin bulk-removes credentials of a type. The path carries no credential type, so the
+            // recompute below decides whether any second factor remains.
+            recordMfaCredentialChange(realmId, userId, event.getTime(), null, true);
+        } else if (CREDENTIALS_PATH_SEGMENT.equals(category) && event.getOperationType() == OperationType.DELETE) {
+            // A specific credential was deleted by an admin (relabel/reorder are not deletions).
+            recordMfaCredentialChange(realmId, userId, event.getTime(), null, true);
+        }
+        // Admins cannot enrol a second factor for a user, so there is no admin "credential added" path.
+    }
+
+    private void recordLogin(String realmId, String userId, long time) {
+        if (realmId == null || userId == null) {
+            return;
+        }
+        persist(new UserActivityEventEntity(KeycloakModelUtils.generateId(), realmId, userId,
+                UserActivityEventEntity.TYPE_LOGIN, null, time));
+    }
+
+    /**
+     * Records an MFA enable/disable row based on the kind of credential change, without consulting any
+     * stored history. {@code removed} marks a credential removal (→ possibly {@code MFA_DISABLED});
+     * otherwise it is an add/update (→ possibly {@code MFA_ENABLED}). The recorded row always reflects
+     * the user's true current MFA state.
+     *
+     * @param credentialType the changed credential's type if known, else {@code null}.
+     */
+    private void recordMfaCredentialChange(String realmId, String userId, long time,
+                                           String credentialType, boolean removed) {
+        // If we know which credential changed and it is not a second factor, MFA state cannot have
+        // changed — skip the user lookup and credential scan entirely (e.g. password changes).
+        if (credentialType != null && !MFA_CREDENTIAL_TYPES.contains(credentialType)) {
+            return;
+        }
+
+        RealmModel realm = resolveRealm(realmId);
+        if (realm == null) {
+            return;
+        }
+        UserModel user = userId == null ? null : session.users().getUserById(realm, userId);
+        if (user == null) {
+            return;
+        }
+
+        boolean hasMfa = hasMfaCredential(user);
+        if (removed) {
+            // Disabled only once the removal leaves no second factor (e.g. removing one of two stays enabled).
+            if (hasMfa) {
+                return;
+            }
+            record(realmId, userId, time, UserActivityEventEntity.TYPE_MFA_DISABLED);
+        } else {
+            // Enabled while a second factor is present (a non-MFA add was filtered out above).
+            if (!hasMfa) {
+                return;
+            }
+            record(realmId, userId, time, UserActivityEventEntity.TYPE_MFA_ENABLED);
+        }
+    }
+
+    private void record(String realmId, String userId, long time, String eventType) {
+        persist(new UserActivityEventEntity(KeycloakModelUtils.generateId(), realmId, userId,
+                eventType, null, time));
+        LOG.debugf("Recorded %s for user %s in realm %s", eventType, userId, realmId);
+    }
+
+    private void recordIdpLinks(String realmId, String userId, long time) {
+        RealmModel realm = resolveRealm(realmId);
+        if (realm == null) {
+            return;
+        }
+        UserModel user = userId == null ? null : session.users().getUserById(realm, userId);
+        if (user == null) {
+            return;
+        }
+
+        IdentityProviderStorageProvider idps = session.identityProviders();
+        List<Map<String, String>> links = session.users().getFederatedIdentitiesStream(realm, user)
+                .map(FederatedIdentityModel::getIdentityProvider)
+                .sorted()
+                .map(alias -> {
+                    Map<String, String> link = new LinkedHashMap<>();
+                    link.put("alias", alias);
+                    link.put("name", displayNameFor(alias, idps.getByAlias(alias)));
+                    return link;
+                })
+                .collect(Collectors.toList());
+
+        String json = toJson(links);
+        persist(new UserActivityEventEntity(KeycloakModelUtils.generateId(), realmId, userId,
+                UserActivityEventEntity.TYPE_IDP_LINKS_CHANGED, json, time));
+        LOG.debugf("Recorded IdP links %s for user %s in realm %s", json, userId, realmId);
+    }
+
+    private static String toJson(Object value) {
+        try {
+            return JsonSerialization.writeValueAsString(value);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to serialize identity-provider links", e);
+        }
+    }
+
+    /**
+     * The IdP's configured display name, or &mdash; when it has none &mdash; a human-readable name
+     * derived from the alias: non-alphanumeric separators become spaces and each word is capitalized
+     * (e.g. {@code "google-tidepool"} &rarr; {@code "Google Tidepool"}).
+     */
+    private static String displayNameFor(String alias, IdentityProviderModel model) {
+        if (model != null) {
+            String displayName = model.getDisplayName();
+            if (displayName != null && !displayName.isBlank()) {
+                return displayName;
+            }
+        }
+        return humanize(alias);
+    }
+
+    private static String humanize(String alias) {
+        StringBuilder humanized = new StringBuilder();
+        for (String word : alias.split("[^a-zA-Z0-9]+")) {
+            if (word.isEmpty()) {
+                continue;
+            }
+            if (humanized.length() > 0) {
+                humanized.append(' ');
+            }
+            humanized.append(Character.toUpperCase(word.charAt(0)))
+                    .append(word.substring(1).toLowerCase(Locale.ROOT));
+        }
+        // Fall back to the raw alias if it had nothing alphanumeric to humanize.
+        return humanized.length() == 0 ? alias : humanized.toString();
+    }
+
+    private RealmModel resolveRealm(String realmId) {
+        return realmId == null ? null : session.realms().getRealm(realmId);
+    }
+
+    private boolean hasMfaCredential(UserModel user) {
+        SubjectCredentialManager credentials = user.credentialManager();
+        return MFA_CREDENTIAL_TYPES.stream()
+                .anyMatch(type -> credentials.getStoredCredentialsByTypeStream(type).findAny().isPresent());
+    }
+
+    private void persist(UserActivityEventEntity entity) {
+        entityManager().persist(entity);
+    }
+
+    // The EntityManager is owned and closed by the Keycloak session/transaction; we must not close it.
+    @SuppressWarnings("resource")
+    private EntityManager entityManager() {
+        return session.getProvider(JpaConnectionProvider.class).getEntityManager();
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProvider.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProvider.java
@@ -1,34 +1,22 @@
 package org.tidepool.keycloak.extensions.activity;
 
-import jakarta.persistence.EntityManager;
 import org.jboss.logging.Logger;
-import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.events.Details;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.EventType;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.OperationType;
-import org.keycloak.models.FederatedIdentityModel;
-import org.keycloak.models.IdentityProviderModel;
-import org.keycloak.models.IdentityProviderStorageProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.SubjectCredentialManager;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.credential.WebAuthnCredentialModel;
-import org.keycloak.models.utils.KeycloakModelUtils;
-import org.keycloak.util.JsonSerialization;
 
-import java.io.IOException;
 import java.util.EnumSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Writes a compact stream of user-activity facts into the {@link UserActivityEventEntity} outbox so an
@@ -70,6 +58,15 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
             EventType.FEDERATED_IDENTITY_LINK, EventType.REMOVE_FEDERATED_IDENTITY,
             EventType.FEDERATED_IDENTITY_OVERRIDE_LINK);
 
+    /**
+     * Note set on a {@code UserSession} once a LOGIN row has been recorded for it. Keycloak fires a
+     * LOGIN event for every client the user reaches, including silent cookie/SSO re-authentications
+     * that reuse the session; the note makes the dedup deterministic — exactly one LOGIN row per
+     * session — without any time-window heuristic (which would mis-handle slow required actions,
+     * SSO bursts, and clock skew).
+     */
+    static final String LOGIN_RECORDED_NOTE = "tidepool-user-activity-login-recorded";
+
     /** Credential types that count as a second factor for the MFA-enabled determination. */
     private static final Set<String> MFA_CREDENTIAL_TYPES = Set.of(
             OTPCredentialModel.TYPE,
@@ -82,16 +79,18 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
     private static final String DISABLE_CREDENTIAL_TYPES_PATH_SEGMENT = "disable-credential-types";
 
     private final KeycloakSession session;
+    private final UserActivityRecorder recorder;
 
     public UserActivityEventListenerProvider(KeycloakSession session) {
         this.session = session;
+        this.recorder = new UserActivityRecorder(session);
     }
 
     @Override
     public void onEvent(Event event) {
         EventType type = event.getType();
         if (type == EventType.LOGIN) {
-            recordLogin(event.getRealmId(), event.getUserId(), event.getTime());
+            recordLogin(event.getRealmId(), event.getUserId(), event.getSessionId(), event.getTime());
         } else if (CREDENTIAL_ADDED_EVENTS.contains(type)) {
             recordMfaCredentialChange(event.getRealmId(), event.getUserId(), event.getTime(),
                     credentialType(event), false);
@@ -139,12 +138,32 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
         // Admins cannot enrol a second factor for a user, so there is no admin "credential added" path.
     }
 
-    private void recordLogin(String realmId, String userId, long time) {
+    private void recordLogin(String realmId, String userId, String sessionId, long time) {
         if (realmId == null || userId == null) {
             return;
         }
-        persist(new UserActivityEventEntity(KeycloakModelUtils.generateId(), realmId, userId,
-                UserActivityEventEntity.TYPE_LOGIN, null, time));
+        // Record exactly one LOGIN per user session: the first LOGIN event marks the session, and the
+        // cookie/SSO re-logins that follow (one per additional client) see the mark and are skipped.
+        // Whenever the session cannot be resolved, fail toward recording rather than losing a login.
+        UserSessionModel userSession = lookupUserSession(realmId, sessionId);
+        if (userSession != null && userSession.getNote(LOGIN_RECORDED_NOTE) != null) {
+            return; // Already recorded for this session — a cookie/SSO re-login for another client.
+        }
+        recorder.recordLogin(realmId, userId, time);
+        if (userSession != null) {
+            userSession.setNote(LOGIN_RECORDED_NOTE, "true");
+        }
+    }
+
+    private UserSessionModel lookupUserSession(String realmId, String sessionId) {
+        if (sessionId == null) {
+            return null;
+        }
+        RealmModel realm = resolveRealm(realmId);
+        if (realm == null) {
+            return null;
+        }
+        return session.sessions().getUserSession(realm, sessionId);
     }
 
     /**
@@ -173,25 +192,13 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
         }
 
         boolean hasMfa = hasMfaCredential(user);
-        if (removed) {
-            // Disabled only once the removal leaves no second factor (e.g. removing one of two stays enabled).
-            if (hasMfa) {
-                return;
-            }
-            record(realmId, userId, time, UserActivityEventEntity.TYPE_MFA_DISABLED);
-        } else {
-            // Enabled while a second factor is present (a non-MFA add was filtered out above).
-            if (!hasMfa) {
-                return;
-            }
-            record(realmId, userId, time, UserActivityEventEntity.TYPE_MFA_ENABLED);
+        // Removal counts as disabled only once no second factor remains (removing one of two stays
+        // enabled); an add/update counts as enabled while a second factor is present.
+        if (removed == hasMfa) {
+            return;
         }
-    }
-
-    private void record(String realmId, String userId, long time, String eventType) {
-        persist(new UserActivityEventEntity(KeycloakModelUtils.generateId(), realmId, userId,
-                eventType, null, time));
-        LOG.debugf("Recorded %s for user %s in realm %s", eventType, userId, realmId);
+        recorder.recordMfa(realmId, userId, hasMfa, time);
+        LOG.debugf("Recorded MFA %s for user %s in realm %s", hasMfa ? "enabled" : "disabled", userId, realmId);
     }
 
     private void recordIdpLinks(String realmId, String userId, long time) {
@@ -203,62 +210,8 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
         if (user == null) {
             return;
         }
-
-        IdentityProviderStorageProvider idps = session.identityProviders();
-        List<Map<String, String>> links = session.users().getFederatedIdentitiesStream(realm, user)
-                .map(FederatedIdentityModel::getIdentityProvider)
-                .sorted()
-                .map(alias -> {
-                    Map<String, String> link = new LinkedHashMap<>();
-                    link.put("alias", alias);
-                    link.put("name", displayNameFor(alias, idps.getByAlias(alias)));
-                    return link;
-                })
-                .collect(Collectors.toList());
-
-        String json = toJson(links);
-        persist(new UserActivityEventEntity(KeycloakModelUtils.generateId(), realmId, userId,
-                UserActivityEventEntity.TYPE_IDP_LINKS_CHANGED, json, time));
-        LOG.debugf("Recorded IdP links %s for user %s in realm %s", json, userId, realmId);
-    }
-
-    private static String toJson(Object value) {
-        try {
-            return JsonSerialization.writeValueAsString(value);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to serialize identity-provider links", e);
-        }
-    }
-
-    /**
-     * The IdP's configured display name, or &mdash; when it has none &mdash; a human-readable name
-     * derived from the alias: non-alphanumeric separators become spaces and each word is capitalized
-     * (e.g. {@code "google-tidepool"} &rarr; {@code "Google Tidepool"}).
-     */
-    private static String displayNameFor(String alias, IdentityProviderModel model) {
-        if (model != null) {
-            String displayName = model.getDisplayName();
-            if (displayName != null && !displayName.isBlank()) {
-                return displayName;
-            }
-        }
-        return humanize(alias);
-    }
-
-    private static String humanize(String alias) {
-        StringBuilder humanized = new StringBuilder();
-        for (String word : alias.split("[^a-zA-Z0-9]+")) {
-            if (word.isEmpty()) {
-                continue;
-            }
-            if (humanized.length() > 0) {
-                humanized.append(' ');
-            }
-            humanized.append(Character.toUpperCase(word.charAt(0)))
-                    .append(word.substring(1).toLowerCase(Locale.ROOT));
-        }
-        // Fall back to the raw alias if it had nothing alphanumeric to humanize.
-        return humanized.length() == 0 ? alias : humanized.toString();
+        recorder.recordIdpLinks(realm, user, time);
+        LOG.debugf("Recorded IdP links for user %s in realm %s", userId, realmId);
     }
 
     private RealmModel resolveRealm(String realmId) {
@@ -269,16 +222,6 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
         SubjectCredentialManager credentials = user.credentialManager();
         return MFA_CREDENTIAL_TYPES.stream()
                 .anyMatch(type -> credentials.getStoredCredentialsByTypeStream(type).findAny().isPresent());
-    }
-
-    private void persist(UserActivityEventEntity entity) {
-        entityManager().persist(entity);
-    }
-
-    // The EntityManager is owned and closed by the Keycloak session/transaction; we must not close it.
-    @SuppressWarnings("resource")
-    private EntityManager entityManager() {
-        return session.getProvider(JpaConnectionProvider.class).getEntityManager();
     }
 
     @Override

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProviderFactory.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProviderFactory.java
@@ -8,6 +8,7 @@ import org.keycloak.events.EventListenerProviderFactory;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.models.utils.PostMigrationEvent;
 import org.keycloak.services.scheduled.ClusterAwareScheduledTaskRunner;
 import org.keycloak.timer.TimerProvider;
 
@@ -62,14 +63,31 @@ public class UserActivityEventListenerProviderFactory implements EventListenerPr
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
-        UserActivityCleanupTask task = new UserActivityCleanupTask(retentionMillis, maxRows);
-        KeycloakModelUtils.runJobInTransaction(factory, session -> {
-            TimerProvider timer = session.getProvider(TimerProvider.class);
-            timer.schedule(new ClusterAwareScheduledTaskRunner(factory, task, cleanupIntervalMillis),
-                    cleanupIntervalMillis, CLEANUP_TASK_NAME);
+        // Defer scheduling until Keycloak is fully initialized. Scheduling a cluster-aware task (which
+        // touches the transaction/cluster infrastructure) directly in postInit runs too early and, in
+        // clustered production mode, aborts server startup. PostMigrationEvent fires once the system is
+        // ready. Any failure here is logged and swallowed so outbox cleanup can never break boot.
+        factory.register(event -> {
+            if (event instanceof PostMigrationEvent) {
+                scheduleCleanup(factory);
+            }
         });
-        LOG.infof("Scheduled user-activity outbox cleanup every %d ms (retention %d ms, max rows %d)",
-                cleanupIntervalMillis, retentionMillis, maxRows);
+    }
+
+    private void scheduleCleanup(KeycloakSessionFactory factory) {
+        try {
+            UserActivityCleanupTask task = new UserActivityCleanupTask(retentionMillis, maxRows);
+            KeycloakModelUtils.runJobInTransaction(factory, session -> {
+                TimerProvider timer = session.getProvider(TimerProvider.class);
+                timer.schedule(new ClusterAwareScheduledTaskRunner(factory, task, cleanupIntervalMillis),
+                        cleanupIntervalMillis, CLEANUP_TASK_NAME);
+            });
+            LOG.infof("Scheduled user-activity outbox cleanup every %d ms (retention %d ms, max rows %d)",
+                    cleanupIntervalMillis, retentionMillis, maxRows);
+        } catch (RuntimeException e) {
+            // Cleanup is best-effort; never let a scheduling failure prevent the server from starting.
+            LOG.error("Failed to schedule user-activity outbox cleanup; the table will not be pruned", e);
+        }
     }
 
     @Override

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProviderFactory.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProviderFactory.java
@@ -1,0 +1,83 @@
+package org.tidepool.keycloak.extensions.activity;
+
+import com.google.auto.service.AutoService;
+import org.jboss.logging.Logger;
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.services.scheduled.ClusterAwareScheduledTaskRunner;
+import org.keycloak.timer.TimerProvider;
+
+/**
+ * Registers {@link UserActivityEventListenerProvider} and schedules the outbox {@link UserActivityCleanupTask}.
+ *
+ * <p>This is a {@linkplain #isGlobal() global} listener, so it runs for every realm with no per-realm
+ * "events listeners" configuration. Retention and pruning are configurable via SPI options, e.g.:
+ *
+ * <pre>
+ *   spi-events-listener-tidepool-user-activity-retention-hours=168       # &lt;= 0 disables age pruning
+ *   spi-events-listener-tidepool-user-activity-max-rows=5000000          # &lt;= 0 disables the size cap
+ *   spi-events-listener-tidepool-user-activity-cleanup-interval-minutes=60
+ * </pre>
+ */
+@AutoService(EventListenerProviderFactory.class)
+public class UserActivityEventListenerProviderFactory implements EventListenerProviderFactory {
+
+    private static final Logger LOG = Logger.getLogger(UserActivityEventListenerProviderFactory.class);
+
+    public static final String PROVIDER_ID = "tidepool-user-activity";
+    public static final String CLEANUP_TASK_NAME = "tidepool-user-activity-cleanup";
+
+    private static final long DEFAULT_RETENTION_HOURS = 168L; // one week
+    private static final long DEFAULT_MAX_ROWS = 5_000_000L;
+    private static final long DEFAULT_CLEANUP_INTERVAL_MINUTES = 60L;
+
+    private long retentionMillis;
+    private long maxRows;
+    private long cleanupIntervalMillis;
+
+    @Override
+    public EventListenerProvider create(KeycloakSession session) {
+        return new UserActivityEventListenerProvider(session);
+    }
+
+    @Override
+    public boolean isGlobal() {
+        // Always active for all realms; no per-realm "eventsListeners" entry required.
+        return true;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        // A non-positive retention disables age-based pruning (consistent with max-rows), rather than
+        // collapsing the cutoff to "now" and wiping the table on every sweep.
+        long retentionHours = config.getLong("retention-hours", DEFAULT_RETENTION_HOURS);
+        retentionMillis = retentionHours > 0 ? retentionHours * 3_600_000L : 0L;
+        maxRows = config.getLong("max-rows", DEFAULT_MAX_ROWS);
+        cleanupIntervalMillis = config.getLong("cleanup-interval-minutes", DEFAULT_CLEANUP_INTERVAL_MINUTES) * 60_000L;
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        UserActivityCleanupTask task = new UserActivityCleanupTask(retentionMillis, maxRows);
+        KeycloakModelUtils.runJobInTransaction(factory, session -> {
+            TimerProvider timer = session.getProvider(TimerProvider.class);
+            timer.schedule(new ClusterAwareScheduledTaskRunner(factory, task, cleanupIntervalMillis),
+                    cleanupIntervalMillis, CLEANUP_TASK_NAME);
+        });
+        LOG.infof("Scheduled user-activity outbox cleanup every %d ms (retention %d ms, max rows %d)",
+                cleanupIntervalMillis, retentionMillis, maxRows);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityJpaEntityProvider.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityJpaEntityProvider.java
@@ -1,0 +1,32 @@
+package org.tidepool.keycloak.extensions.activity;
+
+import org.keycloak.connections.jpa.entityprovider.JpaEntityProvider;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Contributes the {@link UserActivityEventEntity} mapping and its Liquibase changelog to Keycloak's
+ * shared JPA datasource, so the outbox table is created and migrated alongside Keycloak's own schema.
+ */
+public class UserActivityJpaEntityProvider implements JpaEntityProvider {
+
+    @Override
+    public List<Class<?>> getEntities() {
+        return Collections.singletonList(UserActivityEventEntity.class);
+    }
+
+    @Override
+    public String getChangelogLocation() {
+        return "META-INF/tidepool-user-activity-changelog.xml";
+    }
+
+    @Override
+    public String getFactoryId() {
+        return UserActivityJpaEntityProviderFactory.ID;
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityJpaEntityProviderFactory.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityJpaEntityProviderFactory.java
@@ -1,0 +1,40 @@
+package org.tidepool.keycloak.extensions.activity;
+
+import com.google.auto.service.AutoService;
+import org.keycloak.Config;
+import org.keycloak.connections.jpa.entityprovider.JpaEntityProvider;
+import org.keycloak.connections.jpa.entityprovider.JpaEntityProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * Registers {@link UserActivityJpaEntityProvider}. The {@link #ID} is also used as the changelog's
+ * factory id so Keycloak tracks this extension's migrations independently of the core schema.
+ */
+@AutoService(JpaEntityProviderFactory.class)
+public class UserActivityJpaEntityProviderFactory implements JpaEntityProviderFactory {
+
+    public static final String ID = "tidepool-user-activity";
+
+    @Override
+    public JpaEntityProvider create(KeycloakSession session) {
+        return new UserActivityJpaEntityProvider();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityRecorder.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityRecorder.java
@@ -1,0 +1,135 @@
+package org.tidepool.keycloak.extensions.activity;
+
+import jakarta.persistence.EntityManager;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderStorageProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Writes {@link UserActivityEventEntity} rows. Shared by the live {@link UserActivityEventListenerProvider}
+ * and the one-off backfill endpoint so both produce byte-for-byte identical rows. Persists through the
+ * session's shared JPA connection (the transactional-outbox pattern).
+ */
+public class UserActivityRecorder {
+
+    private final KeycloakSession session;
+
+    public UserActivityRecorder(KeycloakSession session) {
+        this.session = session;
+    }
+
+    /** Persist a {@code LOGIN} row. */
+    public void recordLogin(String realmId, String userId, long time) {
+        persist(new UserActivityEventEntity(KeycloakModelUtils.generateId(), realmId, userId,
+                UserActivityEventEntity.TYPE_LOGIN, null, time));
+    }
+
+    /** Persist an {@code MFA_ENABLED} or {@code MFA_DISABLED} row reflecting the user's new MFA state. */
+    public void recordMfa(String realmId, String userId, boolean mfaEnabled, long time) {
+        persist(new UserActivityEventEntity(KeycloakModelUtils.generateId(), realmId, userId,
+                mfaEnabled ? UserActivityEventEntity.TYPE_MFA_ENABLED : UserActivityEventEntity.TYPE_MFA_DISABLED,
+                null, time));
+    }
+
+    /** Persist an {@code IDP_LINKS_CHANGED} row capturing the user's current set of linked IdPs. */
+    public void recordIdpLinks(RealmModel realm, UserModel user, long time) {
+        persistIdpLinks(realm, user, identityProvidersJson(realm, user), time);
+    }
+
+    /**
+     * Like {@link #recordIdpLinks} but skips users with no current links (used by the backfill, which
+     * seeds <em>existing</em> links and should not emit empty {@code []} rows).
+     *
+     * @return whether a row was recorded.
+     */
+    public boolean recordIdpLinksIfPresent(RealmModel realm, UserModel user, long time) {
+        String json = identityProvidersJson(realm, user);
+        if ("[]".equals(json)) {
+            return false;
+        }
+        persistIdpLinks(realm, user, json, time);
+        return true;
+    }
+
+    private void persistIdpLinks(RealmModel realm, UserModel user, String json, long time) {
+        persist(new UserActivityEventEntity(KeycloakModelUtils.generateId(), realm.getId(), user.getId(),
+                UserActivityEventEntity.TYPE_IDP_LINKS_CHANGED, json, time));
+    }
+
+    private void persist(UserActivityEventEntity entity) {
+        entityManager().persist(entity);
+    }
+
+    /** JSON array of the user's linked IdPs, sorted by alias: {@code [{"alias":"google","name":"Google"}]}. */
+    private String identityProvidersJson(RealmModel realm, UserModel user) {
+        IdentityProviderStorageProvider idps = session.identityProviders();
+        List<Map<String, String>> links = session.users().getFederatedIdentitiesStream(realm, user)
+                .map(FederatedIdentityModel::getIdentityProvider)
+                .sorted()
+                .map(alias -> {
+                    Map<String, String> link = new LinkedHashMap<>();
+                    link.put("alias", alias);
+                    link.put("name", displayNameFor(alias, idps.getByAlias(alias)));
+                    return link;
+                })
+                .collect(Collectors.toList());
+        return toJson(links);
+    }
+
+    private static String toJson(Object value) {
+        try {
+            return JsonSerialization.writeValueAsString(value);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to serialize identity-provider links", e);
+        }
+    }
+
+    /**
+     * The IdP's configured display name, or &mdash; when it has none &mdash; a human-readable name
+     * derived from the alias: non-alphanumeric separators become spaces and each word is capitalized
+     * (e.g. {@code "google-tidepool"} &rarr; {@code "Google Tidepool"}).
+     */
+    static String displayNameFor(String alias, IdentityProviderModel model) {
+        if (model != null) {
+            String displayName = model.getDisplayName();
+            if (displayName != null && !displayName.isBlank()) {
+                return displayName;
+            }
+        }
+        return humanize(alias);
+    }
+
+    private static String humanize(String alias) {
+        StringBuilder humanized = new StringBuilder();
+        for (String word : alias.split("[^a-zA-Z0-9]+")) {
+            if (word.isEmpty()) {
+                continue;
+            }
+            if (humanized.length() > 0) {
+                humanized.append(' ');
+            }
+            humanized.append(Character.toUpperCase(word.charAt(0)))
+                    .append(word.substring(1).toLowerCase(Locale.ROOT));
+        }
+        return humanized.length() == 0 ? alias : humanized.toString();
+    }
+
+    // The EntityManager is owned and closed by the Keycloak session/transaction; we must not close it.
+    @SuppressWarnings("resource")
+    private EntityManager entityManager() {
+        return session.getProvider(JpaConnectionProvider.class).getEntityManager();
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/resource/AdminResource.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/resource/AdminResource.java
@@ -22,9 +22,20 @@ public abstract class AdminResource {
     final private KeycloakSession session;
 
     protected AdminPermissionEvaluator auth;
+    private AdminAuth adminAuth;
 
     public AdminResource(KeycloakSession session) {
         this.session = session;
+    }
+
+    /**
+     * Permission evaluator scoped to the given realm. {@link #auth} is scoped to the admin (master)
+     * realm; endpoints that mutate the realm in the request path should check permissions against that
+     * target realm instead &mdash; the same way Keycloak's own admin endpoints evaluate a master-realm
+     * token against the administered realm.
+     */
+    protected AdminPermissionEvaluator authFor(RealmModel realm) {
+        return AdminPermissions.evaluator(session, realm, adminAuth);
     }
 
     protected void setup() {
@@ -62,6 +73,7 @@ public abstract class AdminResource {
         }
 
         AdminAuth adminAuth = new AdminAuth(realm, authResult.getToken(), authResult.getUser(), client);
+        this.adminAuth = adminAuth;
         this.auth = AdminPermissions.evaluator(session, realm, adminAuth);
 
         // Restore the original realm in the context

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/resource/TidepoolAdminResource.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/resource/TidepoolAdminResource.java
@@ -1,9 +1,14 @@
 package org.tidepool.keycloak.extensions.resource;
 
+import org.jboss.logging.Logger;
+import org.keycloak.common.util.Time;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.*;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.tidepool.keycloak.extensions.activity.UserActivityRecorder;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -17,11 +22,15 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class TidepoolAdminResource extends AdminResource {
 
+    private static final Logger LOG = Logger.getLogger(TidepoolAdminResource.class);
+
     private static final String ID_SEPARATOR = ",";
+    private static final int BACKFILL_BATCH_SIZE = 100;
 
     private final KeycloakSession session;
 
@@ -66,6 +75,73 @@ public class TidepoolAdminResource extends AdminResource {
         user.setFederationLink(null);
 
         return Response.status(Response.Status.NO_CONTENT).build();
+    }
+
+    /**
+     * One-off backfill: writes an {@code IDP_LINKS_CHANGED} user-activity row for every user in this realm
+     * that currently has at least one linked identity provider, seeding the outbox with existing links.
+     * Idempotent — re-running just re-records each user's current link set (consumers upsert).
+     *
+     * <p>Runs in batches of {@value #BACKFILL_BATCH_SIZE}, each in its own transaction, so the
+     * persistence context stays bounded and a failure only loses its own batch (counted in
+     * {@code failed}) instead of rolling back the whole run. Users whose links disappeared since the
+     * id query are counted in {@code skipped}.
+     */
+    @POST
+    @Path("backfill-idp-links")
+    @Produces({MediaType.APPLICATION_JSON})
+    public Response backfillIdpLinks() {
+        RealmModel realm = session.getContext().getRealm();
+        // Authorize against the realm being written to, not the admin realm the token was issued by.
+        authFor(realm).realm().requireManageRealm();
+
+        String realmId = realm.getId();
+        long now = Time.currentTimeMillis();
+
+        // Only the users that actually have a federated link, read from Keycloak's FEDERATED_IDENTITY table.
+        @SuppressWarnings({"unchecked", "resource"})
+        List<String> userIds = session.getProvider(JpaConnectionProvider.class).getEntityManager()
+                .createNativeQuery("SELECT DISTINCT user_id FROM federated_identity WHERE realm_id = :realmId")
+                .setParameter("realmId", realmId)
+                .getResultList();
+
+        int backfilled = 0;
+        int skipped = 0;
+        int failed = 0;
+        KeycloakSessionFactory factory = session.getKeycloakSessionFactory();
+        for (int start = 0; start < userIds.size(); start += BACKFILL_BATCH_SIZE) {
+            List<String> batch = userIds.subList(start, Math.min(start + BACKFILL_BATCH_SIZE, userIds.size()));
+            int[] counts = new int[2]; // [recorded, skipped]
+            try {
+                KeycloakModelUtils.runJobInTransaction(factory, batchSession -> {
+                    RealmModel batchRealm = batchSession.realms().getRealm(realmId);
+                    // Fresh sessions have no realm in their context; user lookups require one.
+                    batchSession.getContext().setRealm(batchRealm);
+                    UserActivityRecorder recorder = new UserActivityRecorder(batchSession);
+                    for (String userId : batch) {
+                        UserModel user = batchSession.users().getUserById(batchRealm, userId);
+                        // Skip users (or links) removed since the id query; nothing to seed for them.
+                        if (user != null && recorder.recordIdpLinksIfPresent(batchRealm, user, now)) {
+                            counts[0]++;
+                        } else {
+                            counts[1]++;
+                        }
+                    }
+                });
+                backfilled += counts[0];
+                skipped += counts[1];
+            } catch (RuntimeException e) {
+                failed += batch.size();
+                LOG.errorf(e, "IdP-links backfill batch failed for realm %s (%d user(s) not backfilled)",
+                        realm.getName(), batch.size());
+            }
+        }
+
+        return Response.ok(Map.of(
+                "realm", realm.getName(),
+                "backfilled", backfilled,
+                "skipped", skipped,
+                "failed", failed)).build();
     }
 
     private UserRepresentation toRepresentation(UserModel user, RealmModel realm) {

--- a/admin/src/main/resources/META-INF/services/org.keycloak.connections.jpa.entityprovider.JpaEntityProviderFactory
+++ b/admin/src/main/resources/META-INF/services/org.keycloak.connections.jpa.entityprovider.JpaEntityProviderFactory
@@ -1,0 +1,1 @@
+org.tidepool.keycloak.extensions.activity.UserActivityJpaEntityProviderFactory

--- a/admin/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/admin/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -1,2 +1,3 @@
 org.tidepool.keycloak.extensions.events.RecoveryCodesCleanupEventListenerProviderFactory
 org.tidepool.keycloak.extensions.events.TrustedDeviceCleanupEventListenerProviderFactory
+org.tidepool.keycloak.extensions.activity.UserActivityEventListenerProviderFactory

--- a/admin/src/main/resources/META-INF/tidepool-user-activity-changelog.xml
+++ b/admin/src/main/resources/META-INF/tidepool-user-activity-changelog.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="tidepool" id="tidepool-user-activity-1">
+        <createTable tableName="TIDEPOOL_USER_ACTIVITY_EVENT">
+            <column name="ID" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="REALM_ID" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="USER_ID" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="EVENT_TYPE" type="VARCHAR(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="IDENTITY_PROVIDERS" type="VARCHAR(4000)"/>
+            <column name="EVENT_TIME" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey tableName="TIDEPOOL_USER_ACTIVITY_EVENT" columnNames="ID"
+                       constraintName="PK_TIDEPOOL_USER_ACTIVITY_EVENT"/>
+        <!-- Supports the per-user "last MFA state" lookup. -->
+        <createIndex tableName="TIDEPOOL_USER_ACTIVITY_EVENT" indexName="IDX_TP_ACTIVITY_USER_TIME">
+            <column name="REALM_ID"/>
+            <column name="USER_ID"/>
+            <column name="EVENT_TIME"/>
+        </createIndex>
+        <!-- Supports time- and size-based pruning. -->
+        <createIndex tableName="TIDEPOOL_USER_ACTIVITY_EVENT" indexName="IDX_TP_ACTIVITY_TIME">
+            <column name="EVENT_TIME"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/admin/src/test/java/org/tidepool/keycloak/extensions/activity/UserActivityCleanupTaskTest.java
+++ b/admin/src/test/java/org/tidepool/keycloak/extensions/activity/UserActivityCleanupTaskTest.java
@@ -1,0 +1,102 @@
+package org.tidepool.keycloak.extensions.activity;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.KeycloakSession;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UserActivityCleanupTaskTest {
+
+    private static final long RETENTION_MILLIS = 7L * 24 * 3_600_000L;
+
+    private KeycloakSession session;
+    private EntityManager em;
+    private Query deleteOlderThan;
+    private Query deleteAtOrOlderThan;
+    private TypedQuery<Long> countQuery;
+    private TypedQuery<Long> eventTimesQuery;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        session = mock(KeycloakSession.class);
+        em = mock(EntityManager.class);
+        deleteOlderThan = mock(Query.class);
+        deleteAtOrOlderThan = mock(Query.class);
+        countQuery = mock(TypedQuery.class);
+        eventTimesQuery = mock(TypedQuery.class);
+
+        JpaConnectionProvider jpa = mock(JpaConnectionProvider.class);
+        lenient().when(session.getProvider(JpaConnectionProvider.class)).thenReturn(jpa);
+        lenient().when(jpa.getEntityManager()).thenReturn(em);
+
+        lenient().when(em.createNamedQuery("TidepoolUserActivityEvent.deleteOlderThan")).thenReturn(deleteOlderThan);
+        lenient().when(deleteOlderThan.setParameter(anyString(), org.mockito.ArgumentMatchers.any())).thenReturn(deleteOlderThan);
+        lenient().when(deleteOlderThan.executeUpdate()).thenReturn(3);
+
+        lenient().when(em.createNamedQuery("TidepoolUserActivityEvent.deleteAtOrOlderThan")).thenReturn(deleteAtOrOlderThan);
+        lenient().when(deleteAtOrOlderThan.setParameter(anyString(), org.mockito.ArgumentMatchers.any())).thenReturn(deleteAtOrOlderThan);
+        lenient().when(deleteAtOrOlderThan.executeUpdate()).thenReturn(5);
+
+        lenient().when(em.createNamedQuery("TidepoolUserActivityEvent.count", Long.class)).thenReturn(countQuery);
+
+        lenient().when(em.createNamedQuery("TidepoolUserActivityEvent.eventTimesAsc", Long.class)).thenReturn(eventTimesQuery);
+        lenient().when(eventTimesQuery.setFirstResult(anyInt())).thenReturn(eventTimesQuery);
+        lenient().when(eventTimesQuery.setMaxResults(anyInt())).thenReturn(eventTimesQuery);
+    }
+
+    @Test
+    void deletesByAgeAndSkipsSizeTrimWhenUnderCap() {
+        when(countQuery.getSingleResult()).thenReturn(100L);
+
+        new UserActivityCleanupTask(RETENTION_MILLIS, 1000L).run(session);
+
+        verify(deleteOlderThan).executeUpdate();
+        verify(deleteAtOrOlderThan, never()).executeUpdate();
+    }
+
+    @Test
+    void trimsBySizeWhenOverCap() {
+        when(countQuery.getSingleResult()).thenReturn(1500L); // excess = 500 oldest rows to drop
+        when(eventTimesQuery.getResultList()).thenReturn(List.of(1_700_000_000_000L));
+
+        new UserActivityCleanupTask(RETENTION_MILLIS, 1000L).run(session);
+
+        // Boundary located by scanning only the overflow (offset excess-1 = 499), oldest-first.
+        verify(eventTimesQuery).setFirstResult(499);
+        verify(deleteAtOrOlderThan).setParameter(eq("threshold"), eq(1_700_000_000_000L));
+        verify(deleteAtOrOlderThan).executeUpdate();
+    }
+
+    @Test
+    void skipsSizeTrimWhenDisabled() {
+        new UserActivityCleanupTask(RETENTION_MILLIS, 0L).run(session);
+
+        verify(deleteOlderThan).executeUpdate();
+        verify(em, never()).createNamedQuery("TidepoolUserActivityEvent.count", Long.class);
+        verify(deleteAtOrOlderThan, never()).executeUpdate();
+    }
+
+    @Test
+    void skipsAgePruneWhenRetentionDisabled() {
+        when(countQuery.getSingleResult()).thenReturn(100L);
+
+        new UserActivityCleanupTask(0L, 1000L).run(session); // retention disabled, size cap active
+
+        verify(deleteOlderThan, never()).executeUpdate();
+    }
+}

--- a/admin/src/test/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProviderTest.java
+++ b/admin/src/test/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProviderTest.java
@@ -127,6 +127,9 @@ class UserActivityEventListenerProviderTest {
         assertThat(row.getId()).isNotBlank();
         // The session is marked so subsequent SSO re-logins for it are not recorded again.
         verify(userSession).setNote(UserActivityEventListenerProvider.LOGIN_RECORDED_NOTE, "true");
+        // The durable last-login attribute is updated alongside the outbox row.
+        verify(user).setSingleAttribute(UserActivityEventListenerProvider.LAST_LOGIN_TIME_ATTRIBUTE,
+                Long.toString(EVENT_TIME));
     }
 
     @Test
@@ -138,6 +141,7 @@ class UserActivityEventListenerProviderTest {
 
         verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
         verify(userSession, never()).setNote(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+        verify(user, never()).setSingleAttribute(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
     }
 
     @Test
@@ -195,6 +199,18 @@ class UserActivityEventListenerProviderTest {
         provider.onEvent(event(EventType.UPDATE_CREDENTIAL, "password"));
 
         verify(session, never()).users();
+        verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void ignoresLegacyTotpEvents() {
+        // Keycloak fires the deprecated *_TOTP events as duplicates alongside UPDATE/REMOVE_CREDENTIAL
+        // on every OTP change; reacting to both would record each change twice.
+        stubHasOtp();
+
+        provider.onEvent(event(EventType.UPDATE_TOTP, OTPCredentialModel.TYPE));
+        provider.onEvent(event(EventType.REMOVE_TOTP, OTPCredentialModel.TYPE));
+
         verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
     }
 

--- a/admin/src/test/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProviderTest.java
+++ b/admin/src/test/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProviderTest.java
@@ -1,0 +1,327 @@
+package org.tidepool.keycloak.extensions.activity;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderStorageProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RealmProvider;
+import org.keycloak.models.SubjectCredentialManager;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
+import org.keycloak.models.credential.OTPCredentialModel;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UserActivityEventListenerProviderTest {
+
+    private static final String REALM_ID = "realm-1";
+    private static final String USER_ID = "user-1";
+    private static final long EVENT_TIME = 1_700_000_000_000L;
+
+    private KeycloakSession session;
+    private EntityManager em;
+    private SubjectCredentialManager credentials;
+    private UserProvider users;
+    private RealmModel realm;
+    private UserModel user;
+    private IdentityProviderStorageProvider idps;
+    private UserActivityEventListenerProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        session = mock(KeycloakSession.class);
+        em = mock(EntityManager.class);
+        credentials = mock(SubjectCredentialManager.class);
+        users = mock(UserProvider.class);
+        realm = mock(RealmModel.class);
+        user = mock(UserModel.class);
+        idps = mock(IdentityProviderStorageProvider.class);
+
+        RealmProvider realms = mock(RealmProvider.class);
+        JpaConnectionProvider jpa = mock(JpaConnectionProvider.class);
+
+        lenient().when(session.getProvider(JpaConnectionProvider.class)).thenReturn(jpa);
+        lenient().when(jpa.getEntityManager()).thenReturn(em);
+        lenient().when(session.realms()).thenReturn(realms);
+        lenient().when(session.users()).thenReturn(users);
+        lenient().when(session.identityProviders()).thenReturn(idps);
+        lenient().when(realms.getRealm(REALM_ID)).thenReturn(realm);
+        lenient().when(users.getUserById(realm, USER_ID)).thenReturn(user);
+        lenient().when(user.credentialManager()).thenReturn(credentials);
+
+        // No MFA credentials unless a test stubs them; fresh stream per invocation.
+        lenient().when(credentials.getStoredCredentialsByTypeStream(anyString()))
+                .thenAnswer(inv -> Stream.empty());
+
+        provider = new UserActivityEventListenerProvider(session);
+    }
+
+    private Event event(EventType type) {
+        return event(type, null);
+    }
+
+    private Event event(EventType type, String credentialType) {
+        Event event = mock(Event.class);
+        when(event.getType()).thenReturn(type);
+        lenient().when(event.getRealmId()).thenReturn(REALM_ID);
+        lenient().when(event.getUserId()).thenReturn(USER_ID);
+        lenient().when(event.getTime()).thenReturn(EVENT_TIME);
+        lenient().when(event.getDetails())
+                .thenReturn(credentialType == null ? null : Map.of("credential_type", credentialType));
+        return event;
+    }
+
+    private void stubHasOtp() {
+        when(credentials.getStoredCredentialsByTypeStream(OTPCredentialModel.TYPE))
+                .thenAnswer(inv -> Stream.of(mock(org.keycloak.credential.CredentialModel.class)));
+    }
+
+    private UserActivityEventEntity capturePersisted() {
+        ArgumentCaptor<UserActivityEventEntity> captor = ArgumentCaptor.forClass(UserActivityEventEntity.class);
+        verify(em).persist(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    void recordsLogin() {
+        provider.onEvent(event(EventType.LOGIN));
+
+        UserActivityEventEntity row = capturePersisted();
+        assertThat(row.getEventType()).isEqualTo(UserActivityEventEntity.TYPE_LOGIN);
+        assertThat(row.getRealmId()).isEqualTo(REALM_ID);
+        assertThat(row.getUserId()).isEqualTo(USER_ID);
+        assertThat(row.getEventTime()).isEqualTo(EVENT_TIME);
+        assertThat(row.getId()).isNotBlank();
+    }
+
+    @Test
+    void recordsMfaEnabledWhenSecondFactorAdded() {
+        stubHasOtp(); // user now has a second factor
+
+        provider.onEvent(event(EventType.UPDATE_CREDENTIAL, OTPCredentialModel.TYPE));
+
+        UserActivityEventEntity row = capturePersisted();
+        assertThat(row.getEventType()).isEqualTo(UserActivityEventEntity.TYPE_MFA_ENABLED);
+    }
+
+    @Test
+    void recordsMfaDisabledWhenLastSecondFactorRemoved() {
+        // No OTP remains after the removal -> disabled.
+        provider.onEvent(event(EventType.REMOVE_CREDENTIAL, OTPCredentialModel.TYPE));
+
+        UserActivityEventEntity row = capturePersisted();
+        assertThat(row.getEventType()).isEqualTo(UserActivityEventEntity.TYPE_MFA_DISABLED);
+    }
+
+    @Test
+    void skipsMfaDisabledWhenAnotherSecondFactorRemains() {
+        stubHasOtp(); // removed one device but another second factor still exists
+
+        provider.onEvent(event(EventType.REMOVE_CREDENTIAL, OTPCredentialModel.TYPE));
+
+        verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void skipsMfaEnabledWhenNoSecondFactorPresent() {
+        // An add/update event but the user has no second factor (e.g. the added credential was not MFA);
+        // must not emit MFA_ENABLED.
+        provider.onEvent(event(EventType.UPDATE_CREDENTIAL, null));
+
+        verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void shortCircuitsNonMfaCredentialTypeWithoutTouchingUser() {
+        // A password change carries credential_type=password; MFA state cannot have changed, so we
+        // skip the user lookup and credential scan entirely.
+        provider.onEvent(event(EventType.UPDATE_CREDENTIAL, "password"));
+
+        verify(session, never()).users();
+        verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void doesNotDisableForNonMfaCredentialRemoval() {
+        // Removing a password (credential_type=password) is short-circuited: no MFA row even though the
+        // user has no second factor.
+        provider.onEvent(event(EventType.REMOVE_CREDENTIAL, "password"));
+
+        verify(session, never()).users();
+        verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void recordsIdpLinksSortedWithNamesAsJson() {
+        FederatedIdentityModel google = federatedIdentity("google");
+        FederatedIdentityModel apple = federatedIdentity("apple");
+        when(users.getFederatedIdentitiesStream(realm, user)).thenReturn(Stream.of(google, apple));
+        stubIdp("google", "Google");
+        stubIdp("apple", "Apple");
+
+        provider.onEvent(event(EventType.FEDERATED_IDENTITY_LINK));
+
+        UserActivityEventEntity row = capturePersisted();
+        assertThat(row.getEventType()).isEqualTo(UserActivityEventEntity.TYPE_IDP_LINKS_CHANGED);
+        assertThat(row.getIdentityProviders())
+                .isEqualTo("[{\"alias\":\"apple\",\"name\":\"Apple\"},{\"alias\":\"google\",\"name\":\"Google\"}]");
+    }
+
+    @Test
+    void humanizesAliasWhenIdpHasNoDisplayName() {
+        FederatedIdentityModel idp = federatedIdentity("google_tidepool-home");
+        when(users.getFederatedIdentitiesStream(realm, user)).thenReturn(Stream.of(idp));
+        stubIdp("google_tidepool-home", null); // no display name -> derive one from the alias
+
+        provider.onEvent(event(EventType.FEDERATED_IDENTITY_LINK));
+
+        UserActivityEventEntity row = capturePersisted();
+        assertThat(row.getIdentityProviders())
+                .isEqualTo("[{\"alias\":\"google_tidepool-home\",\"name\":\"Google Tidepool Home\"}]");
+    }
+
+    @Test
+    void humanizesAliasWhenIdpModelMissing() {
+        FederatedIdentityModel idp = federatedIdentity("azure-ad");
+        when(users.getFederatedIdentitiesStream(realm, user)).thenReturn(Stream.of(idp));
+        when(idps.getByAlias("azure-ad")).thenReturn(null); // IdP config gone but link remains
+
+        provider.onEvent(event(EventType.FEDERATED_IDENTITY_LINK));
+
+        UserActivityEventEntity row = capturePersisted();
+        assertThat(row.getIdentityProviders()).isEqualTo("[{\"alias\":\"azure-ad\",\"name\":\"Azure Ad\"}]");
+    }
+
+    @Test
+    void recordsEmptyIdpLinksWhenLastRemoved() {
+        when(users.getFederatedIdentitiesStream(realm, user)).thenReturn(Stream.empty());
+
+        provider.onEvent(event(EventType.REMOVE_FEDERATED_IDENTITY));
+
+        UserActivityEventEntity row = capturePersisted();
+        assertThat(row.getEventType()).isEqualTo(UserActivityEventEntity.TYPE_IDP_LINKS_CHANGED);
+        assertThat(row.getIdentityProviders()).isEqualTo("[]");
+    }
+
+    @Test
+    void ignoresUnrelatedEvents() {
+        Event refresh = mock(Event.class);
+        when(refresh.getType()).thenReturn(EventType.REFRESH_TOKEN);
+
+        provider.onEvent(refresh);
+
+        verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
+        verify(session, never()).users();
+    }
+
+    @Test
+    void recordsMfaDisabledFromAdminCredentialDeletion() {
+        // Admin deletes the user's last second factor; none remain -> disabled.
+        provider.onEvent(adminEvent("users/" + USER_ID + "/credentials/cred-1", OperationType.DELETE), false);
+
+        UserActivityEventEntity row = capturePersisted();
+        assertThat(row.getEventType()).isEqualTo(UserActivityEventEntity.TYPE_MFA_DISABLED);
+    }
+
+    @Test
+    void recordsMfaDisabledFromAdminDisableCredentialTypes() {
+        provider.onEvent(adminEvent("users/" + USER_ID + "/disable-credential-types", OperationType.ACTION), false);
+
+        UserActivityEventEntity row = capturePersisted();
+        assertThat(row.getEventType()).isEqualTo(UserActivityEventEntity.TYPE_MFA_DISABLED);
+    }
+
+    @Test
+    void skipsAdminCredentialDeletionWhenAnotherFactorRemains() {
+        stubHasOtp(); // another second factor still exists after the deletion
+
+        provider.onEvent(adminEvent("users/" + USER_ID + "/credentials/cred-1", OperationType.DELETE), false);
+
+        verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void ignoresAdminCredentialRelabel() {
+        // A non-DELETE credential operation (e.g. setting a label) is not a removal.
+        provider.onEvent(adminEvent("users/" + USER_ID + "/credentials/cred-1/userLabel", OperationType.UPDATE), false);
+
+        verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void recordsIdpLinksFromAdminLink() {
+        FederatedIdentityModel google = federatedIdentity("google");
+        when(users.getFederatedIdentitiesStream(realm, user)).thenReturn(Stream.of(google));
+        stubIdp("google", "Google");
+
+        provider.onEvent(adminEvent("users/" + USER_ID + "/federated-identity/google"), false);
+
+        UserActivityEventEntity row = capturePersisted();
+        assertThat(row.getEventType()).isEqualTo(UserActivityEventEntity.TYPE_IDP_LINKS_CHANGED);
+        assertThat(row.getIdentityProviders()).isEqualTo("[{\"alias\":\"google\",\"name\":\"Google\"}]");
+    }
+
+    @Test
+    void ignoresFailedAdminEvents() {
+        AdminEvent failed = mock(AdminEvent.class);
+        lenient().when(failed.getError()).thenReturn("could_not_delete");
+        lenient().when(failed.getResourcePath()).thenReturn("users/" + USER_ID + "/credentials/cred-1");
+
+        provider.onEvent(failed, false);
+
+        verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void ignoresUnrelatedAdminEvents() {
+        provider.onEvent(adminEvent("users/" + USER_ID + "/reset-password"), false);
+        provider.onEvent(adminEvent("groups/group-1"), false);
+
+        verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    private AdminEvent adminEvent(String resourcePath) {
+        return adminEvent(resourcePath, null);
+    }
+
+    private AdminEvent adminEvent(String resourcePath, OperationType operationType) {
+        AdminEvent event = mock(AdminEvent.class);
+        lenient().when(event.getError()).thenReturn(null);
+        lenient().when(event.getRealmId()).thenReturn(REALM_ID);
+        lenient().when(event.getResourcePath()).thenReturn(resourcePath);
+        lenient().when(event.getOperationType()).thenReturn(operationType);
+        lenient().when(event.getTime()).thenReturn(EVENT_TIME);
+        return event;
+    }
+
+    private static FederatedIdentityModel federatedIdentity(String alias) {
+        FederatedIdentityModel model = mock(FederatedIdentityModel.class);
+        when(model.getIdentityProvider()).thenReturn(alias);
+        return model;
+    }
+
+    private void stubIdp(String alias, String displayName) {
+        IdentityProviderModel model = mock(IdentityProviderModel.class);
+        lenient().when(model.getDisplayName()).thenReturn(displayName);
+        when(idps.getByAlias(alias)).thenReturn(model);
+    }
+}

--- a/admin/src/test/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProviderTest.java
+++ b/admin/src/test/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProviderTest.java
@@ -17,6 +17,8 @@ import org.keycloak.models.RealmProvider;
 import org.keycloak.models.SubjectCredentialManager;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.UserSessionProvider;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.mockito.ArgumentCaptor;
 
@@ -35,6 +37,7 @@ class UserActivityEventListenerProviderTest {
 
     private static final String REALM_ID = "realm-1";
     private static final String USER_ID = "user-1";
+    private static final String SESSION_ID = "session-1";
     private static final long EVENT_TIME = 1_700_000_000_000L;
 
     private KeycloakSession session;
@@ -44,6 +47,8 @@ class UserActivityEventListenerProviderTest {
     private RealmModel realm;
     private UserModel user;
     private IdentityProviderStorageProvider idps;
+    private UserSessionProvider sessions;
+    private UserSessionModel userSession;
     private UserActivityEventListenerProvider provider;
 
     @BeforeEach
@@ -55,6 +60,7 @@ class UserActivityEventListenerProviderTest {
         realm = mock(RealmModel.class);
         user = mock(UserModel.class);
         idps = mock(IdentityProviderStorageProvider.class);
+        sessions = mock(UserSessionProvider.class);
 
         RealmProvider realms = mock(RealmProvider.class);
         JpaConnectionProvider jpa = mock(JpaConnectionProvider.class);
@@ -64,9 +70,15 @@ class UserActivityEventListenerProviderTest {
         lenient().when(session.realms()).thenReturn(realms);
         lenient().when(session.users()).thenReturn(users);
         lenient().when(session.identityProviders()).thenReturn(idps);
+        lenient().when(session.sessions()).thenReturn(sessions);
         lenient().when(realms.getRealm(REALM_ID)).thenReturn(realm);
         lenient().when(users.getUserById(realm, USER_ID)).thenReturn(user);
         lenient().when(user.credentialManager()).thenReturn(credentials);
+
+        // Default: the login's session exists and carries no recorded-login note (fresh login).
+        userSession = mock(UserSessionModel.class);
+        lenient().when(userSession.getNote(UserActivityEventListenerProvider.LOGIN_RECORDED_NOTE)).thenReturn(null);
+        lenient().when(sessions.getUserSession(realm, SESSION_ID)).thenReturn(userSession);
 
         // No MFA credentials unless a test stubs them; fresh stream per invocation.
         lenient().when(credentials.getStoredCredentialsByTypeStream(anyString()))
@@ -84,11 +96,13 @@ class UserActivityEventListenerProviderTest {
         when(event.getType()).thenReturn(type);
         lenient().when(event.getRealmId()).thenReturn(REALM_ID);
         lenient().when(event.getUserId()).thenReturn(USER_ID);
+        lenient().when(event.getSessionId()).thenReturn(SESSION_ID);
         lenient().when(event.getTime()).thenReturn(EVENT_TIME);
         lenient().when(event.getDetails())
                 .thenReturn(credentialType == null ? null : Map.of("credential_type", credentialType));
         return event;
     }
+
 
     private void stubHasOtp() {
         when(credentials.getStoredCredentialsByTypeStream(OTPCredentialModel.TYPE))
@@ -111,6 +125,30 @@ class UserActivityEventListenerProviderTest {
         assertThat(row.getUserId()).isEqualTo(USER_ID);
         assertThat(row.getEventTime()).isEqualTo(EVENT_TIME);
         assertThat(row.getId()).isNotBlank();
+        // The session is marked so subsequent SSO re-logins for it are not recorded again.
+        verify(userSession).setNote(UserActivityEventListenerProvider.LOGIN_RECORDED_NOTE, "true");
+    }
+
+    @Test
+    void skipsLoginWhenSessionAlreadyRecorded() {
+        // Cookie/SSO re-login for another client: the session already carries the recorded-login note.
+        when(userSession.getNote(UserActivityEventListenerProvider.LOGIN_RECORDED_NOTE)).thenReturn("true");
+
+        provider.onEvent(event(EventType.LOGIN));
+
+        verify(em, never()).persist(org.mockito.ArgumentMatchers.any());
+        verify(userSession, never()).setNote(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void recordsLoginWhenSessionMissing() {
+        // Session not found (e.g. expired between event and lookup): record rather than lose a login.
+        when(sessions.getUserSession(realm, SESSION_ID)).thenReturn(null);
+
+        provider.onEvent(event(EventType.LOGIN));
+
+        UserActivityEventEntity row = capturePersisted();
+        assertThat(row.getEventType()).isEqualTo(UserActivityEventEntity.TYPE_LOGIN);
     }
 
     @Test


### PR DESCRIPTION
Persists user login activity using the outbox pattern so it can be synced to the clinic service: JPA entity + Liquibase changelog, event listener, recorder, cleanup task, and admin resource endpoint. Includes docs and tests.

---
📚 **Stacked PR 5 of 8.** Base branch: `tk-stack-4-2fa-cleanup-listeners` — review/merge it first.

**Stack — review & merge bottom-up:**

1. `tk-stack-1-trusted-device-spi` → `master`
2. `tk-stack-2-attempted-username-fix` → `tk-stack-1-trusted-device-spi`
3. `tk-stack-3-aia-authenticator` → `tk-stack-2-attempted-username-fix`
4. `tk-stack-4-2fa-cleanup-listeners` → `tk-stack-3-aia-authenticator`
5. `tk-stack-5-login-activity-outbox` → `tk-stack-4-2fa-cleanup-listeners`
6. `tk-stack-6-email-changed-notification` → `tk-stack-5-login-activity-outbox`
7. `tk-stack-7-cancelable-email-change` → `tk-stack-6-email-changed-notification`
8. `tk-stack-8-theme-redesign` → `tk-stack-7-cancelable-email-change`

_Builds green on JDK 21 (`./mvnw clean compile package`); on the stack tip 42 admin + 35 home-idp tests pass._