### PR TITLE
[BACK-4440] Add email-changed notification

### DIFF
--- a/admin/src/main/java/org/tidepool/keycloak/extensions/events/EmailChangedNotificationEventListenerProvider.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/events/EmailChangedNotificationEventListenerProvider.java
@@ -1,0 +1,135 @@
+package org.tidepool.keycloak.extensions.events;
+
+import org.jboss.logging.Logger;
+import org.keycloak.email.EmailException;
+import org.keycloak.email.EmailTemplateProvider;
+import org.keycloak.events.Details;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventType;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.UserModelDelegate;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Notifies a user's <em>previous</em> email address whenever their account email changes, so the
+ * original mailbox owner can detect an unexpected change (e.g. an account takeover).
+ *
+ * <p>Keycloak fires {@link EventType#UPDATE_EMAIL} (the self-service update-email required action)
+ * and the legacy {@link EventType#UPDATE_PROFILE} <em>after</em> the new address is persisted. Both
+ * carry {@link Details#PREVIOUS_EMAIL} / {@link Details#UPDATED_EMAIL} details, but only when the
+ * email actually changed &mdash; so the presence of a previous email is our change signal, and it is
+ * the address we notify.
+ *
+ * <p>Because the change is already committed by the time the event fires, {@link UserModel#getEmail()}
+ * returns the <em>new</em> address; {@link EmailTemplateProvider} delivers to whatever that getter
+ * returns. We therefore wrap the user in a {@link UserModelDelegate} whose {@code getEmail()} returns
+ * the previous address, redirecting delivery to the old mailbox.
+ *
+ * <p>Admin-initiated email changes are intentionally out of scope: an {@link AdminEvent} exposes only
+ * the new email, not the previous address we would need to notify.
+ */
+public class EmailChangedNotificationEventListenerProvider implements EventListenerProvider {
+
+    private static final Logger LOG = Logger.getLogger(EmailChangedNotificationEventListenerProvider.class);
+
+    static final String SUBJECT_MESSAGE_KEY = "emailChangedNotificationSubject";
+    static final String TEMPLATE_NAME = "email-changed-notification.ftl";
+
+    private final KeycloakSession session;
+
+    public EmailChangedNotificationEventListenerProvider(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        if (event == null) {
+            return;
+        }
+        EventType type = event.getType();
+        if (type != EventType.UPDATE_EMAIL && type != EventType.UPDATE_PROFILE) {
+            return;
+        }
+
+        Map<String, String> details = event.getDetails();
+        if (details == null) {
+            return;
+        }
+        String previousEmail = details.get(Details.PREVIOUS_EMAIL);
+        String updatedEmail = details.get(Details.UPDATED_EMAIL);
+
+        // previous_email / updated_email are only set when the email actually changed, so a present
+        // previous address is the change signal. Guard against blank/unchanged values regardless.
+        if (previousEmail == null || previousEmail.isBlank()) {
+            return;
+        }
+        if (updatedEmail != null && previousEmail.equalsIgnoreCase(updatedEmail)) {
+            return;
+        }
+
+        sendNotification(event, previousEmail, updatedEmail);
+    }
+
+    @Override
+    public void onEvent(AdminEvent event, boolean includeRepresentation) {
+        // Admin-initiated email changes are intentionally out of scope; the AdminEvent does not
+        // expose the previous email address required to notify the old mailbox.
+    }
+
+    private void sendNotification(Event event, String previousEmail, String updatedEmail) {
+        String realmId = event.getRealmId();
+        String userId = event.getUserId();
+        if (realmId == null || userId == null) {
+            return;
+        }
+
+        RealmModel realm = session.realms().getRealm(realmId);
+        if (realm == null) {
+            return;
+        }
+
+        UserModel user = session.users().getUserById(realm, userId);
+        if (user == null) {
+            return;
+        }
+
+        // The user's email is already the NEW address; redirect delivery to the previous address.
+        UserModel previousEmailRecipient = new UserModelDelegate(user) {
+            @Override
+            public String getEmail() {
+                return previousEmail;
+            }
+        };
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("newEmail", updatedEmail != null ? updatedEmail : user.getEmail());
+        attributes.put("changedAt", Instant.ofEpochMilli(event.getTime()).truncatedTo(ChronoUnit.SECONDS).toString());
+        if (event.getIpAddress() != null && !event.getIpAddress().isBlank()) {
+            attributes.put("ipAddress", event.getIpAddress());
+        }
+
+        try {
+            session.getProvider(EmailTemplateProvider.class)
+                    .setRealm(realm)
+                    .setUser(previousEmailRecipient)
+                    .send(SUBJECT_MESSAGE_KEY, TEMPLATE_NAME, attributes);
+            LOG.infof("Sent email-change notification to the previous address of user %s in realm %s",
+                    userId, realm.getName());
+        } catch (EmailException e) {
+            LOG.warnf(e, "Failed to send email-change notification to the previous address of user %s in realm %s",
+                    userId, realm.getName());
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/events/EmailChangedNotificationEventListenerProviderFactory.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/events/EmailChangedNotificationEventListenerProviderFactory.java
@@ -1,0 +1,49 @@
+package org.tidepool.keycloak.extensions.events;
+
+import com.google.auto.service.AutoService;
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * Registers {@link EmailChangedNotificationEventListenerProvider}.
+ *
+ * <p>This is a {@linkplain #isGlobal() global} event listener, so it runs for every realm without
+ * any per-realm configuration &mdash; there is no need to add {@value #PROVIDER_ID} to a realm's
+ * event listeners.
+ */
+@AutoService(EventListenerProviderFactory.class)
+public class EmailChangedNotificationEventListenerProviderFactory implements EventListenerProviderFactory {
+
+    public static final String PROVIDER_ID = "tidepool-email-changed-notification";
+
+    @Override
+    public EventListenerProvider create(KeycloakSession session) {
+        return new EmailChangedNotificationEventListenerProvider(session);
+    }
+
+    @Override
+    public boolean isGlobal() {
+        // Always active for all realms; no per-realm "eventsListeners" entry required.
+        return true;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/admin/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/admin/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -1,3 +1,4 @@
 org.tidepool.keycloak.extensions.events.RecoveryCodesCleanupEventListenerProviderFactory
 org.tidepool.keycloak.extensions.events.TrustedDeviceCleanupEventListenerProviderFactory
+org.tidepool.keycloak.extensions.events.EmailChangedNotificationEventListenerProviderFactory
 org.tidepool.keycloak.extensions.activity.UserActivityEventListenerProviderFactory

--- a/admin/src/test/java/org/tidepool/keycloak/extensions/events/EmailChangedNotificationEventListenerProviderTest.java
+++ b/admin/src/test/java/org/tidepool/keycloak/extensions/events/EmailChangedNotificationEventListenerProviderTest.java
@@ -1,0 +1,152 @@
+package org.tidepool.keycloak.extensions.events;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.email.EmailTemplateProvider;
+import org.keycloak.events.Details;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RealmProvider;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EmailChangedNotificationEventListenerProviderTest {
+
+    private static final String REALM_ID = "realm-1";
+    private static final String USER_ID = "user-1";
+    private static final String OLD_EMAIL = "old@example.com";
+    private static final String NEW_EMAIL = "new@example.com";
+
+    private KeycloakSession session;
+    private UserModel user;
+    private EmailTemplateProvider emailTemplateProvider;
+    private EmailChangedNotificationEventListenerProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        session = mock(KeycloakSession.class);
+        RealmProvider realms = mock(RealmProvider.class);
+        UserProvider users = mock(UserProvider.class);
+        RealmModel realm = mock(RealmModel.class);
+        user = mock(UserModel.class);
+        emailTemplateProvider = mock(EmailTemplateProvider.class);
+
+        lenient().when(session.realms()).thenReturn(realms);
+        lenient().when(session.users()).thenReturn(users);
+        lenient().when(realms.getRealm(REALM_ID)).thenReturn(realm);
+        lenient().when(users.getUserById(realm, USER_ID)).thenReturn(user);
+        lenient().when(realm.getName()).thenReturn("test-realm");
+        // The user's email is already the NEW address by the time the event fires.
+        lenient().when(user.getEmail()).thenReturn(NEW_EMAIL);
+
+        lenient().when(session.getProvider(EmailTemplateProvider.class)).thenReturn(emailTemplateProvider);
+        lenient().when(emailTemplateProvider.setRealm(any())).thenReturn(emailTemplateProvider);
+        lenient().when(emailTemplateProvider.setUser(any(UserModel.class))).thenReturn(emailTemplateProvider);
+
+        provider = new EmailChangedNotificationEventListenerProvider(session);
+    }
+
+    private Event emailChangeEvent(EventType type, String previousEmail, String updatedEmail) {
+        Map<String, String> details = new HashMap<>();
+        if (previousEmail != null) {
+            details.put(Details.PREVIOUS_EMAIL, previousEmail);
+        }
+        if (updatedEmail != null) {
+            details.put(Details.UPDATED_EMAIL, updatedEmail);
+        }
+        Event event = mock(Event.class);
+        when(event.getType()).thenReturn(type);
+        lenient().when(event.getDetails()).thenReturn(details);
+        lenient().when(event.getRealmId()).thenReturn(REALM_ID);
+        lenient().when(event.getUserId()).thenReturn(USER_ID);
+        lenient().when(event.getTime()).thenReturn(1_700_000_000_000L);
+        lenient().when(event.getIpAddress()).thenReturn("203.0.113.7");
+        return event;
+    }
+
+    @Test
+    void notifiesPreviousAddressOnUpdateEmail() throws Exception {
+        provider.onEvent(emailChangeEvent(EventType.UPDATE_EMAIL, OLD_EMAIL, NEW_EMAIL));
+
+        // Delivery is redirected to the previous address, not the user's (new) email.
+        ArgumentCaptor<UserModel> recipient = ArgumentCaptor.forClass(UserModel.class);
+        verify(emailTemplateProvider).setUser(recipient.capture());
+        assertThat(recipient.getValue().getEmail()).isEqualTo(OLD_EMAIL);
+
+        ArgumentCaptor<Map<String, Object>> attrs = ArgumentCaptor.forClass(Map.class);
+        verify(emailTemplateProvider).send(
+                eq(EmailChangedNotificationEventListenerProvider.SUBJECT_MESSAGE_KEY),
+                eq(EmailChangedNotificationEventListenerProvider.TEMPLATE_NAME),
+                attrs.capture());
+        assertThat(attrs.getValue())
+                .containsEntry("newEmail", NEW_EMAIL)
+                .containsEntry("ipAddress", "203.0.113.7")
+                .containsKey("changedAt");
+    }
+
+    @Test
+    void notifiesPreviousAddressOnLegacyUpdateProfile() throws Exception {
+        provider.onEvent(emailChangeEvent(EventType.UPDATE_PROFILE, OLD_EMAIL, NEW_EMAIL));
+
+        ArgumentCaptor<UserModel> recipient = ArgumentCaptor.forClass(UserModel.class);
+        verify(emailTemplateProvider).setUser(recipient.capture());
+        assertThat(recipient.getValue().getEmail()).isEqualTo(OLD_EMAIL);
+        verify(emailTemplateProvider).send(anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    void ignoresUpdateProfileWithoutEmailChange() throws Exception {
+        // No previous_email detail => the profile update did not change the email.
+        provider.onEvent(emailChangeEvent(EventType.UPDATE_PROFILE, null, null));
+
+        verify(session, never()).getProvider(EmailTemplateProvider.class);
+        verify(emailTemplateProvider, never()).send(anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    void ignoresWhenPreviousEqualsUpdated() throws Exception {
+        provider.onEvent(emailChangeEvent(EventType.UPDATE_EMAIL, NEW_EMAIL, NEW_EMAIL));
+
+        verify(emailTemplateProvider, never()).send(anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    void ignoresUnrelatedUserEvents() {
+        Event event = mock(Event.class);
+        when(event.getType()).thenReturn(EventType.LOGIN);
+
+        provider.onEvent(event);
+
+        verify(session, never()).realms();
+        verify(session, never()).users();
+        verify(session, never()).getProvider(EmailTemplateProvider.class);
+    }
+
+    @Test
+    void fallsBackToCurrentEmailWhenUpdatedDetailMissing() throws Exception {
+        // UPDATE_EMAIL with previous but no updated detail still notifies; newEmail falls back to
+        // the user's current (already-updated) address.
+        provider.onEvent(emailChangeEvent(EventType.UPDATE_EMAIL, OLD_EMAIL, null));
+
+        ArgumentCaptor<Map<String, Object>> attrs = ArgumentCaptor.forClass(Map.class);
+        verify(emailTemplateProvider).send(anyString(), anyString(), attrs.capture());
+        assertThat(attrs.getValue()).containsEntry("newEmail", NEW_EMAIL);
+    }
+}

--- a/tidepool-theme/email/html/email-changed-notification.ftl
+++ b/tidepool-theme/email/html/email-changed-notification.ftl
@@ -1,0 +1,13 @@
+<#import "template.ftl" as layout>
+<#-- Tidepool addition: sent to a user's PREVIOUS email address when their account email changes, -->
+<#-- so the original mailbox owner can detect an unexpected change. Informational only — no CTA. -->
+<#-- Attributes are supplied by EmailChangedNotificationEventListenerProvider: newEmail, changedAt -->
+<#-- (ISO-8601 UTC), and optionally ipAddress. Body copy inlined in English to match the other -->
+<#-- Tidepool emails. -->
+<@layout.emailLayout displayHeader=true displayAction=false; section>
+    <#if section = "header">
+        Hey there!
+    <#elseif section = "content">
+        The email address for your Tidepool account was changed to ${newEmail}.<br /><br />This change was made on ${changedAt}<#if ipAddress?has_content> from IP address ${ipAddress}</#if>.<br /><br />If you made this change, no action is needed. If you did not request it, please contact Tidepool Support right away.
+    </#if>
+</@layout.emailLayout>

--- a/tidepool-theme/email/messages/messages_en.properties
+++ b/tidepool-theme/email/messages/messages_en.properties
@@ -7,4 +7,5 @@ executeActionsBodyHtml=<p>Tidepool requests that you update your {2} account by 
 eventLoginErrorSubject=Tidepool login error
 eventRemoveTotpSubject=Tidepool OTP removed
 eventUpdateTotpSubject=Tidepool OTP updated
+emailChangedNotificationSubject=Your Tidepool account email address was changed
 

--- a/tidepool-theme/email/text/email-changed-notification.ftl
+++ b/tidepool-theme/email/text/email-changed-notification.ftl
@@ -1,0 +1,12 @@
+<#ftl output_format="plainText">
+<#-- Plain-text counterpart of html/email-changed-notification.ftl. Keycloak renders BOTH a text and -->
+<#-- an html body for every email, so this must exist or the send fails with TemplateNotFoundException. -->
+<#-- Attributes supplied by EmailChangedNotificationEventListenerProvider: newEmail, changedAt (ISO-8601 -->
+<#-- UTC), and optionally ipAddress. -->
+Hey there!
+
+The email address for your Tidepool account was changed to ${newEmail}.
+
+This change was made on ${changedAt}<#if ipAddress?has_content> from IP address ${ipAddress}</#if>.
+
+If you made this change, no action is needed. If you did not request it, please contact Tidepool Support right away.


### PR DESCRIPTION
Sends a notification to the user's previous email address when their email changes. Adds the event listener, the `email-changed-notification.ftl` template, and the message key.

---
📚 **Stacked PR 6 of 8.** Base branch: `tk-stack-5-login-activity-outbox` — review/merge it first.

**Stack — review & merge bottom-up:**

1. `tk-stack-1-trusted-device-spi` → `master`
2. `tk-stack-2-attempted-username-fix` → `tk-stack-1-trusted-device-spi`
3. `tk-stack-3-aia-authenticator` → `tk-stack-2-attempted-username-fix`
4. `tk-stack-4-2fa-cleanup-listeners` → `tk-stack-3-aia-authenticator`
5. `tk-stack-5-login-activity-outbox` → `tk-stack-4-2fa-cleanup-listeners`
6. `tk-stack-6-email-changed-notification` → `tk-stack-5-login-activity-outbox`
7. `tk-stack-7-cancelable-email-change` → `tk-stack-6-email-changed-notification`
8. `tk-stack-8-theme-redesign` → `tk-stack-7-cancelable-email-change`

_Builds green on JDK 21 (`./mvnw clean compile package`); on the stack tip 42 admin + 35 home-idp tests pass._