### PR TITLE
[BACK-4437] Add cancelable update-email required action

### DIFF
--- a/admin/src/main/java/org/tidepool/keycloak/extensions/requiredactions/CancelableUpdateEmail.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/requiredactions/CancelableUpdateEmail.java
@@ -1,0 +1,112 @@
+package org.tidepool.keycloak.extensions.requiredactions;
+
+import com.google.auto.service.AutoService;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.RequiredActionContext;
+import org.keycloak.authentication.RequiredActionFactory;
+import org.keycloak.authentication.requiredactions.UpdateEmail;
+import org.keycloak.models.Constants;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+/**
+ * Overrides the built-in {@code UPDATE_EMAIL} required action to offer a cancel button when the
+ * action is an <em>enforced</em> application-initiated action (AIA).
+ *
+ * <p>Keycloak hides the standard {@code cancel-aia} button whenever a requested
+ * {@code kc_action=UPDATE_EMAIL} also matches a pending required action on the user: the auth
+ * session note {@link Constants#KC_ACTION_ENFORCED} is set, and
+ * {@code FreeMarkerLoginFormsProvider} consequently omits the {@code isAppInitiatedAction} flag the
+ * template keys off. The user is then stuck on the update-email form with no way out.
+ *
+ * <p>This subclass surfaces a Tidepool cancel button whenever the change can be safely abandoned:
+ * either the action is an enforced AIA, or an unverified {@link UserModel#EMAIL_PENDING pending
+ * email} change exists (so the user still has a current, verified email to fall back on).
+ * Cancelling discards the pending email and removes the {@code UPDATE_EMAIL} required action, so the
+ * account keeps its current email. (With email verification enabled the primary email is never
+ * changed until the new address is verified, so there is nothing to roll back &mdash; only the
+ * pending change is dropped.)
+ *
+ * <p>The cancel path is gated on {@link #isCancelAllowed(RequiredActionContext)} both when rendering
+ * and when handling the submit. A plain {@code UPDATE_EMAIL} required action forced on login with no
+ * pending change yet therefore cannot be skipped &mdash; there must be a pending change to abandon
+ * (or an enforced AIA).
+ *
+ * <p>Registered with {@code getId() == "UPDATE_EMAIL"} (inherited), it replaces the built-in
+ * provider for that id &mdash; Keycloak's factory loading is last-write-wins and module providers
+ * load after built-ins.
+ */
+@AutoService(RequiredActionFactory.class)
+public class CancelableUpdateEmail extends UpdateEmail {
+
+    private static final Logger LOG = Logger.getLogger(CancelableUpdateEmail.class);
+
+    /** Form attribute consumed by {@code update-email.ftl} to render the cancel button. */
+    static final String CANCEL_ALLOWED_ATTRIBUTE = "updateEmailCancelAllowed";
+
+    /** Submit-button name posted when the user cancels an enforced email update. */
+    static final String CANCEL_PARAMETER = "cancel-update-email";
+
+    @Override
+    public void requiredActionChallenge(RequiredActionContext context) {
+        if (isCancelAllowed(context)) {
+            // Standard cancel-aia is unavailable here (enforced AIA, or a pending required action on
+            // login); expose our own. Set before delegating: the LoginFormsProvider is cached per
+            // session, so the attribute persists into the form super renders.
+            context.form().setAttribute(CANCEL_ALLOWED_ATTRIBUTE, true);
+        }
+        super.requiredActionChallenge(context);
+    }
+
+    @Override
+    public void processAction(RequiredActionContext context) {
+        MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
+        if (formData.containsKey(CANCEL_PARAMETER) && isCancelAllowed(context)) {
+            UserModel user = context.getUser();
+            // Drop the unverified pending email and clear the action; the current email stands.
+            user.removeAttribute(UserModel.EMAIL_PENDING);
+            user.removeRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL);
+            LOG.debugf("User %s cancelled the update-email action; keeping the current email",
+                    user.getId());
+            context.success();
+            return;
+        }
+        // A successful submit re-renders the "verification email sent" confirmation form from inside
+        // super.processAction (via sendEmailUpdateConfirmation), bypassing requiredActionChallenge.
+        // Expose the cancel button on that form too. This only governs button visibility; the cancel
+        // action above stays gated on isCancelAllowed, so a mandatory update still cannot be skipped.
+        if (isCancelAllowed(context) || isEmailSubmission(formData)) {
+            context.form().setAttribute(CANCEL_ALLOWED_ATTRIBUTE, true);
+        }
+        super.processAction(context);
+    }
+
+    /** A non-blank email value is being submitted (i.e. a change that will land on the confirmation form). */
+    static boolean isEmailSubmission(MultivaluedMap<String, String> formData) {
+        String email = formData.getFirst(UserModel.EMAIL);
+        return email != null && !email.isBlank();
+    }
+
+    /**
+     * Whether the user may cancel the email update: when the action is an enforced AIA (the standard
+     * cancel-aia button is suppressed) or when an unverified pending email change already exists. In
+     * both cases the user has a current verified email to keep, so abandoning the change is safe.
+     */
+    static boolean isCancelAllowed(RequiredActionContext context) {
+        return isEnforcedAppInitiatedAction(context) || hasPendingEmail(context);
+    }
+
+    private static boolean hasPendingEmail(RequiredActionContext context) {
+        UserModel user = context.getUser();
+        return user != null && user.getFirstAttribute(UserModel.EMAIL_PENDING) != null;
+    }
+
+    static boolean isEnforcedAppInitiatedAction(RequiredActionContext context) {
+        AuthenticationSessionModel authSession = context.getAuthenticationSession();
+        if (authSession == null) {
+            return false;
+        }
+        return Boolean.TRUE.toString().equals(authSession.getClientNote(Constants.KC_ACTION_ENFORCED));
+    }
+}

--- a/admin/src/main/resources/META-INF/services/org.keycloak.authentication.RequiredActionFactory
+++ b/admin/src/main/resources/META-INF/services/org.keycloak.authentication.RequiredActionFactory
@@ -1,2 +1,3 @@
 org.tidepool.keycloak.extensions.roles.UserRolePromptRequiredAction
 org.tidepool.keycloak.extensions.terms.TidepoolTermsRequiredAction
+org.tidepool.keycloak.extensions.requiredactions.CancelableUpdateEmail

--- a/admin/src/test/java/org/tidepool/keycloak/extensions/requiredactions/CancelableUpdateEmailTest.java
+++ b/admin/src/test/java/org/tidepool/keycloak/extensions/requiredactions/CancelableUpdateEmailTest.java
@@ -1,0 +1,128 @@
+package org.tidepool.keycloak.extensions.requiredactions;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.authentication.RequiredActionContext;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.Constants;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CancelableUpdateEmailTest {
+
+    private RequiredActionContext context;
+    private AuthenticationSessionModel authSession;
+    private UserModel user;
+    private MultivaluedMap<String, String> formData;
+    private CancelableUpdateEmail action;
+
+    @BeforeEach
+    void setUp() {
+        context = mock(RequiredActionContext.class);
+        authSession = mock(AuthenticationSessionModel.class);
+        user = mock(UserModel.class);
+        HttpRequest httpRequest = mock(HttpRequest.class);
+        formData = new MultivaluedHashMap<>();
+
+        lenient().when(context.getAuthenticationSession()).thenReturn(authSession);
+        lenient().when(context.getUser()).thenReturn(user);
+        lenient().when(context.getHttpRequest()).thenReturn(httpRequest);
+        lenient().when(httpRequest.getDecodedFormParameters()).thenReturn(formData);
+        lenient().when(user.getId()).thenReturn("user-1");
+
+        action = new CancelableUpdateEmail();
+    }
+
+    private void markEnforced() {
+        when(authSession.getClientNote(Constants.KC_ACTION_ENFORCED)).thenReturn(Boolean.TRUE.toString());
+    }
+
+    private void markPendingEmail() {
+        when(user.getFirstAttribute(UserModel.EMAIL_PENDING)).thenReturn("new@tidepool.org");
+    }
+
+    @Test
+    void cancellingEnforcedActionClearsPendingEmailAndRequiredAction() {
+        markEnforced();
+        formData.putSingle(CancelableUpdateEmail.CANCEL_PARAMETER, "true");
+
+        action.processAction(context);
+
+        verify(user).removeAttribute(UserModel.EMAIL_PENDING);
+        verify(user).removeRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL);
+        verify(context).success();
+    }
+
+    @Test
+    void cancellingPendingChangeClearsPendingEmailWhenNotEnforced() {
+        // Plain required-action-on-login (not enforced) but a pending email change exists.
+        markPendingEmail();
+        formData.putSingle(CancelableUpdateEmail.CANCEL_PARAMETER, "true");
+
+        action.processAction(context);
+
+        verify(user).removeAttribute(UserModel.EMAIL_PENDING);
+        verify(user).removeRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL);
+        verify(context).success();
+    }
+
+    @Test
+    void cancelNotAllowedWhenNeitherEnforcedNorPending() {
+        // No enforcement and no pending change: cancel is gated off, so processAction falls through
+        // to super and a forged cancel submit cannot skip a mandatory update.
+        assertThat(CancelableUpdateEmail.isCancelAllowed(context)).isFalse();
+    }
+
+    @Test
+    void cancelAllowedWhenPendingEmailExists() {
+        markPendingEmail();
+        assertThat(CancelableUpdateEmail.isCancelAllowed(context)).isTrue();
+    }
+
+    @Test
+    void cancelAllowedWhenEnforced() {
+        markEnforced();
+        assertThat(CancelableUpdateEmail.isCancelAllowed(context)).isTrue();
+    }
+
+    @Test
+    void emailSubmissionDetectsNonBlankEmailField() {
+        MultivaluedMap<String, String> empty = new MultivaluedHashMap<>();
+        assertThat(CancelableUpdateEmail.isEmailSubmission(empty)).isFalse();
+
+        MultivaluedMap<String, String> blank = new MultivaluedHashMap<>();
+        blank.putSingle(UserModel.EMAIL, "  ");
+        assertThat(CancelableUpdateEmail.isEmailSubmission(blank)).isFalse();
+
+        MultivaluedMap<String, String> filled = new MultivaluedHashMap<>();
+        filled.putSingle(UserModel.EMAIL, "new@tidepool.org");
+        assertThat(CancelableUpdateEmail.isEmailSubmission(filled)).isTrue();
+    }
+
+    @Test
+    void enforcedDetectionReflectsClientNote() {
+        // No note -> not enforced.
+        lenient().when(authSession.getClientNote(Constants.KC_ACTION_ENFORCED)).thenReturn(null);
+        assertThat(CancelableUpdateEmail.isEnforcedAppInitiatedAction(context)).isFalse();
+
+        when(authSession.getClientNote(Constants.KC_ACTION_ENFORCED)).thenReturn("false");
+        assertThat(CancelableUpdateEmail.isEnforcedAppInitiatedAction(context)).isFalse();
+
+        markEnforced();
+        assertThat(CancelableUpdateEmail.isEnforcedAppInitiatedAction(context)).isTrue();
+    }
+
+    @Test
+    void enforcedDetectionFalseWithoutAuthSession() {
+        when(context.getAuthenticationSession()).thenReturn(null);
+        assertThat(CancelableUpdateEmail.isEnforcedAppInitiatedAction(context)).isFalse();
+    }
+}


### PR DESCRIPTION
Adds the `CancelableUpdateEmail` required action so users can cancel an enforced email change.

> **Backend only.** The matching `update-email.ftl` cancel-button wiring was moved to the theme-redesign PR (`tk-stack-8-theme-redesign`).

---
📚 **Stacked PR 7 of 8.** Base branch: `tk-stack-6-email-changed-notification` — review/merge it first.

**Stack — review & merge bottom-up:**

1. `tk-stack-1-trusted-device-spi` → `master`
2. `tk-stack-2-attempted-username-fix` → `tk-stack-1-trusted-device-spi`
3. `tk-stack-3-aia-authenticator` → `tk-stack-2-attempted-username-fix`
4. `tk-stack-4-2fa-cleanup-listeners` → `tk-stack-3-aia-authenticator`
5. `tk-stack-5-login-activity-outbox` → `tk-stack-4-2fa-cleanup-listeners`
6. `tk-stack-6-email-changed-notification` → `tk-stack-5-login-activity-outbox`
7. `tk-stack-7-cancelable-email-change` → `tk-stack-6-email-changed-notification`
8. `tk-stack-8-theme-redesign` → `tk-stack-7-cancelable-email-change`

_Builds green on JDK 21 (`./mvnw clean compile package`); on the stack tip 42 admin + 35 home-idp tests pass._