### PR TITLE
[BACK-4437] Address login-theme design-review feedback

### DIFF
--- a/tidepool-theme/login/error.ftl
+++ b/tidepool-theme/login/error.ftl
@@ -1,15 +1,25 @@
 <#import "template.ftl" as layout>
+<#import "tp-commons.ftl" as tp>
+<#-- Expired action-token links opened without an auth session (e.g. in a -->
+<#-- different browser) render here instead of restarting the login flow. -->
+<#-- Show the same dedicated link-expired card as login-username.ftl (Figma -->
+<#-- node 14515:80071). -->
+<#assign actionLinkExpired = tp.isActionLinkExpired()>
 <@layout.registrationLayout displayMessage=false; section>
     <#if section = "header">
-        ${kcSanitize(msg("errorTitle"))?no_esc}
+        <#if actionLinkExpired>${msg("linkExpiredTitle")}<#else>${kcSanitize(msg("errorTitle"))?no_esc}</#if>
     <#elseif section = "form">
         <div id="kc-error-message">
-            <p class="instruction">${kcSanitize(message.summary)?no_esc}</p>
-            <#if traceId??>
-                <p class="instruction" id="traceId">${msg("traceIdSupportMessage", traceId)}</p>
-            </#if>
-            <#if !skipLink?? && client?? && client.baseUrl?has_content>
-                <a id="backToApplication" href="${client.baseUrl}" class="${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} tp-back-to-app">${msg("backToApplication")}</a>
+            <#if actionLinkExpired>
+                <@tp.linkExpiredBody/>
+            <#else>
+                <p class="instruction">${kcSanitize(message.summary)?no_esc}</p>
+                <#if traceId??>
+                    <p class="instruction" id="traceId">${msg("traceIdSupportMessage", traceId)}</p>
+                </#if>
+                <#if !skipLink?? && client?? && client.baseUrl?has_content>
+                    <a id="backToApplication" href="${client.baseUrl}" class="${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} tp-back-to-app">${msg("backToApplication")}</a>
+                </#if>
             </#if>
         </div>
     </#if>

--- a/tidepool-theme/login/info.ftl
+++ b/tidepool-theme/login/info.ftl
@@ -8,7 +8,9 @@
         </#if>
     <#elseif section = "form">
         <div id="kc-info-message">
-            <p class="instruction">${message.summary}<#if requiredActions??><#list requiredActions>: <b><#items as reqActionItem>${kcSanitize(msg("requiredAction.${reqActionItem}"))?no_esc}<#sep>, </#items></b></#list><#else></#if></p>
+            <#-- Sanitized so messages can carry markup (e.g. the bolded address in
+                 emailUpdateConfirmationSent); kcSanitize strips anything unsafe. -->
+            <p class="instruction">${kcSanitize(message.summary)?no_esc}<#if requiredActions??><#list requiredActions>: <b><#items as reqActionItem>${kcSanitize(msg("requiredAction.${reqActionItem}"))?no_esc}<#sep>, </#items></b></#list><#else></#if></p>
             <#if !skipLink??>
                 <#if pageRedirectUri?has_content>
                     <a href="${pageRedirectUri}" class="${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} tp-back-to-app">${msg("backToApplication")}</a>

--- a/tidepool-theme/login/login-config-totp.ftl
+++ b/tidepool-theme/login/login-config-totp.ftl
@@ -3,7 +3,7 @@
 <#import "password-commons.ftl" as passwordCommons>
 <#-- Split TOTP setup into two visual steps with client-side step transitions: -->
 <#--   1. QR-code step: shows the authenticator app list + QR code (or manual secret). -->
-<#--   2. Verify step:  device label + 6-digit code + "log out other sessions". -->
+<#--   2. Verify step:  6-digit code + device label + "log out other sessions". -->
 <#-- Both steps share one POST form. JS-only navigation. If the server returns a -->
 <#-- validation error on totp or userLabel, the form starts on step 2 so the error -->
 <#-- is visible and re-submission picks up where the user left off. -->
@@ -78,19 +78,19 @@
                     <p class="tp-totp-section-help">${msg("loginTotpVerifyHelp")}</p>
                 </div>
 
-                <@field.group name="userLabel" label=msg("loginTotpDeviceLabel") error=messagesPerField.get('userLabel') required=true>
-                    <span class="${properties.kcInputClass!} <#if messagesPerField.existsError('userLabel')>${properties.kcError!}</#if>">
-                        <input type="text" id="userLabel" name="userLabel" autocomplete="off" maxlength="200"
-                               aria-invalid="<#if messagesPerField.existsError('userLabel')>true</#if>"/>
-                        <@field.errorIcon error=messagesPerField.get('userLabel')/>
-                    </span>
-                </@field.group>
-
                 <@field.group name="totp" label=msg("loginTotpCodeLabel") error=messagesPerField.get('totp') required=true>
                     <span class="${properties.kcInputClass!} <#if messagesPerField.existsError('totp')>${properties.kcError!}</#if>">
                         <input type="text" id="totp" name="totp" autocomplete="one-time-code" inputmode="numeric"
                                aria-invalid="<#if messagesPerField.existsError('totp')>true</#if>"/>
                         <@field.errorIcon error=messagesPerField.get('totp')/>
+                    </span>
+                </@field.group>
+
+                <@field.group name="userLabel" label=msg("loginTotpDeviceLabel") error=messagesPerField.get('userLabel') required=true>
+                    <span class="${properties.kcInputClass!} <#if messagesPerField.existsError('userLabel')>${properties.kcError!}</#if>">
+                        <input type="text" id="userLabel" name="userLabel" autocomplete="off" maxlength="200"
+                               aria-invalid="<#if messagesPerField.existsError('userLabel')>true</#if>"/>
+                        <@field.errorIcon error=messagesPerField.get('userLabel')/>
                     </span>
                 </@field.group>
 
@@ -127,7 +127,7 @@
                 function setStep(step) {
                     form.dataset.step = step;
                     if (step === 'verify') {
-                        setTimeout(function () { userLabel && userLabel.focus(); }, 0);
+                        setTimeout(function () { totp && totp.focus(); }, 0);
                     }
                 }
 

--- a/tidepool-theme/login/login-config-totp.ftl
+++ b/tidepool-theme/login/login-config-totp.ftl
@@ -20,6 +20,11 @@
               novalidate="novalidate"
               data-step="${initialStep}">
 
+            <#-- Default submit for Enter — in AIA mode step 1's Cancel is the form's -->
+            <#-- first submit button, so Enter in the step-2 code/label fields would -->
+            <#-- cancel the whole setup. The unnamed stub submits like saveTOTPBtn, -->
+            <#-- and the submit listener below validates it like any normal save. -->
+            <input type="submit" class="tp-default-submit" tabindex="-1" aria-hidden="true"/>
             <input type="hidden" id="totpSecret" name="totpSecret" value="${totp.totpSecret}"/>
             <#if mode??><input type="hidden" id="mode" name="mode" value="${mode}"/></#if>
 

--- a/tidepool-theme/login/login-recovery-authn-code-config.ftl
+++ b/tidepool-theme/login/login-recovery-authn-code-config.ftl
@@ -47,6 +47,13 @@
         </div>
 
         <form action="${url.loginAction}" class="${properties.kcFormClass!} tp-recovery-form" id="kc-recovery-codes-settings-form" method="post">
+            <#-- Default submit for Enter — the confirmation checkbox lives inside this -->
+            <#-- form and in the AIA branch the visible Cancel is the first submit, so -->
+            <#-- browsers that implicitly submit from a focused checkbox (Firefox) -->
+            <#-- would cancel the setup. Unnamed like the Finish input, and mirrors its -->
+            <#-- disabled state so Enter can't bypass the unchecked confirmation gate: -->
+            <#-- a disabled default button makes implicit submission a no-op. -->
+            <input type="submit" id="tpRecoveryDefaultSubmit" class="tp-default-submit" tabindex="-1" aria-hidden="true" disabled/>
             <input type="hidden" name="generatedRecoveryAuthnCodes" value="${recoveryAuthnCodesConfigBean.generatedRecoveryAuthnCodesAsString}"/>
             <input type="hidden" name="generatedAt" value="${recoveryAuthnCodesConfigBean.generatedAt?c}"/>
             <input type="hidden" id="userLabel" name="userLabel" value="${msg("recovery-codes-label-default")}"/>
@@ -54,7 +61,7 @@
             <div class="tp-recovery-confirm">
                 <label class="tp-recovery-confirm-label">
                     <input type="checkbox" id="kcRecoveryCodesConfirmationCheck" name="kcRecoveryCodesConfirmationCheck"
-                           onchange="document.getElementById('saveRecoveryAuthnCodesBtn').disabled = !this.checked;"/>
+                           onchange="document.getElementById('saveRecoveryAuthnCodesBtn').disabled = document.getElementById('tpRecoveryDefaultSubmit').disabled = !this.checked;"/>
                     <span>${msg("recovery-codes-confirmation-message")}</span>
                 </label>
             </div>

--- a/tidepool-theme/login/login-update-password.ftl
+++ b/tidepool-theme/login/login-update-password.ftl
@@ -7,6 +7,12 @@
         ${msg("updatePasswordTitle")}
     <#elseif section = "form">
         <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post" novalidate="novalidate">
+            <#-- Default submit for Enter — in the AIA branch the visible Cancel submit -->
+            <#-- renders before the primary, so without this stub implicit submission -->
+            <#-- would cancel. Unnamed on purpose: nothing reads the primary's "login" -->
+            <#-- param, and a second element named "login" would break the onsubmit -->
+            <#-- double-submit guard above. -->
+            <input type="submit" class="tp-default-submit" tabindex="-1" aria-hidden="true"/>
             <@field.password name="password-new" label=msg("passwordNew") fieldName="password" autocomplete="new-password" autofocus=true />
             <@field.password name="password-confirm" label=msg("passwordConfirm") autocomplete="new-password" />
 

--- a/tidepool-theme/login/login-username.ftl
+++ b/tidepool-theme/login/login-username.ftl
@@ -2,10 +2,21 @@
 <#import "field.ftl" as field>
 <#import "social-providers.ftl" as identityProviders>
 <#import "passkeys.ftl" as passkeys>
-<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username') displayInfo=(realm.password && realm.registrationAllowed && !registrationDisabled??); section>
+<#import "tp-commons.ftl" as tp>
+<#-- Expired action-token links (password reset, email verification, update-email -->
+<#-- confirmation) restart the browser flow and land here with the generic -->
+<#-- "Action expired" error alert. Render the dedicated link-expired card (Figma -->
+<#-- node 14515:80071) instead of the login form in that case. The no-session -->
+<#-- variant of the same expiry renders via error.ftl, which carries the same -->
+<#-- detection. -->
+<#assign actionLinkExpired = tp.isActionLinkExpired()>
+<@layout.registrationLayout displayMessage=(!actionLinkExpired && !messagesPerField.existsError('username')) displayInfo=(!actionLinkExpired && realm.password && realm.registrationAllowed && !registrationDisabled??); section>
     <#if section = "header">
-        ${msg("loginAccountTitle")}
+        <#if actionLinkExpired>${msg("linkExpiredTitle")}<#else>${msg("loginAccountTitle")}</#if>
     <#elseif section = "form">
+        <#if actionLinkExpired>
+            <@tp.linkExpiredBody/>
+        <#else>
         <div id="kc-form">
             <div id="kc-form-wrapper">
                 <#if realm.password>
@@ -52,6 +63,7 @@
             </div>
         </div>
         <@passkeys.conditionalUIData />
+        </#if>
 
     <#elseif section = "info">
         <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
@@ -60,7 +72,7 @@
             </div>
         </#if>
     <#elseif section = "socialProviders">
-        <#if realm.password && social.providers?? && social.providers?has_content>
+        <#if !actionLinkExpired && realm.password && social.providers?? && social.providers?has_content>
             <@identityProviders.show social=social />
         </#if>
     </#if>

--- a/tidepool-theme/login/messages/messages_en.properties
+++ b/tidepool-theme/login/messages/messages_en.properties
@@ -86,7 +86,7 @@ updateEmailSubtitle=Enter your new email address to update your account.
 updateEmailFieldLabel=New email
 updateEmailSubmit=Update Email
 # Shown on info.ftl after the user submits a new email address.
-emailUpdateConfirmationSent=A confirmation email has been sent to {0}. You need to confirm via email to complete the update and activate your new email address.
+emailUpdateConfirmationSent=A confirmation email has been sent to <b>{0}</b><br>Click the link to complete the update and activate your new email address.
 # Success page shown after the user clicks the confirmation link in their inbox.
 emailUpdatedTitle=Your email has been updated
 emailUpdated=Your account email has been successfully updated to {0}

--- a/tidepool-theme/login/messages/messages_en.properties
+++ b/tidepool-theme/login/messages/messages_en.properties
@@ -6,6 +6,10 @@ enterEmail=Enter email
 next=Next
 noAccount=Don''t have an account?
 doRegister=Sign Up
+# Shown under the email field when no account matches. Overrides the
+# home-idp-discovery SPI's bundled "Unknown email." (same copy as the
+# legacy theme).
+unknownEmailMessage=This email doesn''t belong to an account yet.
 
 # login-password.ftl
 notYou=Not you?
@@ -14,10 +18,10 @@ missingPasswordMessage=Please enter your password.
 doForgotPassword=Forgot your password?
 
 # login-reset-password.ftl
-emailResetLinkInstruction=We will send you a link to reset your password on the following email.
+emailResetLinkInstruction=We will send you a link to reset your password at the following email.
 # Success alert shown on the login screen after submitting the reset form.
 # Rendered via kcSanitize, so <strong> and <br> are preserved.
-emailSentMessage=<strong>Password reset link sent to your email, It may take a few minutes to arrive.</strong><br>If the email hasn’t arrived yet, please check your spam folder. Alternatively you can also request the email again.
+emailSentMessage=<strong>A password reset link has been sent to your email. It may take a few minutes to arrive.</strong><br>If the email hasn''t arrived after a few minutes, check your spam folder or request the email again.
 
 # Registration flow (register-personal.ftl, register-clinician.ftl,
 # user_role_prompt.ftl, clinician_terms.ftl, patient_terms.ftl). Copy carried
@@ -108,8 +112,8 @@ recovery-code-config-header=Save your recovery codes
 loginRecoveryConfigDownloadTitle=Download recovery codes
 loginRecoveryConfigDownloadDescription=Never worry about getting locked out of your account. These single-use recovery codes are a backup option in case you cannot access your authenticator app.
 loginRecoveryConfigLearnMore=Learn how to store recovery codes safely
-recovery-code-config-warning-title=Make sure to save these recovery codes in a safe place. You will not be able to access them again after you leave this page.
-recovery-code-config-warning-message=Download or copy these codes and store them somewhere separate from your phone, such as a password manager.
+recovery-code-config-warning-title=Save these codes and store them in a safe place separate from your phone, such as in a password manager.
+recovery-code-config-warning-message=You will not be able to access these codes after you leave this page.
 recovery-codes-confirmation-message=I have saved these codes someplace safe
 recovery-codes-action-complete=Finish
 

--- a/tidepool-theme/login/messages/messages_en.properties
+++ b/tidepool-theme/login/messages/messages_en.properties
@@ -142,7 +142,7 @@ loginTotpDeviceLabel=Name this personal device
 loginTotpCodeLabel=Enter the 6-Digit code (OTP)
 loginTotpUserLabelRequired=Please provide a unique name for this device
 loginTotpAddDevice=Add Device
-loginTotpSupportPrompt=Asked for additional details? Check our support docs or click on help
+loginTotpSupportPrompt=Need help setting up your authenticator app? Visit our support documentation.
 # Override upstream's "Sign out from other devices" — Figma copy is more explicit.
 logoutOtherSessions=Log out of all other devices and active sessions
 

--- a/tidepool-theme/login/messages/messages_en.properties
+++ b/tidepool-theme/login/messages/messages_en.properties
@@ -85,6 +85,10 @@ linkExpiredMessage=It looks like this link has expired or the request was cancel
 updateEmailSubtitle=Enter your new email address to update your account.
 updateEmailFieldLabel=New email
 updateEmailSubmit=Update Email
+# Info alert on the update-email form while an unverified email change is pending
+# (the resend/cancel gate). MessageFormat is applied ({0} = pending email), so
+# literal apostrophes must be doubled.
+emailVerificationPending=A verification email has been sent to <a href="mailto:{0}"><b>{0}</b></a>. Please verify your email address to complete the update and continue accessing your account.<br>Didn''t receive the email? You can resend it or enter a different email address below. To keep using your current email address, click Cancel.
 # Shown on info.ftl after the user submits a new email address.
 emailUpdateConfirmationSent=A confirmation email has been sent to <b>{0}</b><br>Click the link to complete the update and activate your new email address.
 # Success page shown after the user clicks the confirmation link in their inbox.

--- a/tidepool-theme/login/messages/messages_en.properties
+++ b/tidepool-theme/login/messages/messages_en.properties
@@ -76,6 +76,11 @@ loginOtpImportant=You must have access to your authenticator app or a recovery c
 pageExpiredRestart=Restart the login process
 pageExpiredContinue=Continue the login process
 
+# Expired action-token links (password reset, email verification, update-email
+# confirmation). Rendered as a dedicated card — Figma node 14515:80071.
+linkExpiredTitle=This link is no longer active
+linkExpiredMessage=It looks like this link has expired or the request was cancelled. To continue, go back to your account settings and start a new request.
+
 # update-email.ftl
 updateEmailSubtitle=Enter your new email address to update your account.
 updateEmailFieldLabel=New email

--- a/tidepool-theme/login/register-clinician.ftl
+++ b/tidepool-theme/login/register-clinician.ftl
@@ -40,6 +40,7 @@
                 </div>
             </div>
         </form>
+        <@registerCommons.completionGate/>
     <#elseif section = "info">
         <div id="kc-registration">
             <span>${msg("alreadyHaveAnAccount")} <a href="${url.loginRestartFlowUrl}">${msg("doLogIn")}</a></span>

--- a/tidepool-theme/login/register-commons.ftl
+++ b/tidepool-theme/login/register-commons.ftl
@@ -34,3 +34,44 @@
         </div>
     </#if>
 </#macro>
+
+<#-- Disables the Sign Up button until every required field is filled in (and -->
+<#-- the terms checkbox, when present, is checked). Required fields are the -->
+<#-- ones whose form-group label carries the required-asterisk span — field.ftl -->
+<#-- never emits the HTML required attribute, so the marker is the only signal. -->
+<#-- The button is enabled in markup and disabled from JS so the form still -->
+<#-- submits without JS; server-side validation remains the authority. -->
+<#macro completionGate>
+    <script>
+        (function () {
+            var form = document.getElementById('kc-register-form');
+            if (!form) return;
+            var submit = form.querySelector('button[type="submit"]');
+            if (!submit) return;
+
+            function isComplete() {
+                var fields = form.querySelectorAll('input, select, textarea');
+                for (var i = 0; i < fields.length; i++) {
+                    var f = fields[i];
+                    if (f.type === 'hidden' || f.type === 'submit' || f.type === 'button' || f.disabled) continue;
+                    if (!f.getClientRects().length) continue;
+                    if (f.type === 'checkbox') {
+                        if (f.id === 'terms' && !f.checked) return false;
+                        continue;
+                    }
+                    var group = f.closest('.pf-v5-c-form__group');
+                    if (group && group.querySelector('.pf-v5-c-form__label-required') && !f.value.trim()) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            function update() { submit.disabled = !isComplete(); }
+
+            form.addEventListener('input', update);
+            form.addEventListener('change', update);
+            update();
+        })();
+    </script>
+</#macro>

--- a/tidepool-theme/login/register-personal.ftl
+++ b/tidepool-theme/login/register-personal.ftl
@@ -1,6 +1,7 @@
 <#import "template.ftl" as layout>
 <#import "field.ftl" as field>
 <#import "user-profile-commons.ftl" as userProfileCommons>
+<#import "register-commons.ftl" as registerCommons>
 <@layout.registrationLayout displayMessage=messagesPerField.exists('global') displayRequiredFields=false displayInfo=true; section>
     <#if section = "header">
         ${msg("registerTitlePersonal")}
@@ -37,6 +38,7 @@
                 </div>
             </div>
         </form>
+        <@registerCommons.completionGate/>
     <#elseif section = "info">
         <div id="kc-registration">
             <span>${msg("alreadyHaveAnAccount")} <a href="${url.loginRestartFlowUrl}">${msg("doLogIn")}</a></span>

--- a/tidepool-theme/login/resources/css/tidepool.css
+++ b/tidepool-theme/login/resources/css/tidepool.css
@@ -1500,6 +1500,18 @@ body[data-page-id="login-trusted-device-register"] #kc-form-trusted-device {
   gap: 32px;
 }
 
+/* On mobile the No/Yes labels are too long to share a row — stack the pair */
+/* full-width with the primary (Yes, trust this device) on top. Desktop keeps */
+/* the side-by-side No | Yes order from the Figma frame. */
+@media (max-width: 767px) {
+  body[data-page-id="login-trusted-device-register"] .tp-totp-actions {
+    grid-template-columns: 1fr;
+  }
+  body[data-page-id="login-trusted-device-register"] .tp-totp-actions > .pf-m-primary {
+    order: -1;
+  }
+}
+
 .tp-trusted-device-explanation {
   display: flex;
   flex-direction: column;

--- a/tidepool-theme/login/resources/css/tidepool.css
+++ b/tidepool-theme/login/resources/css/tidepool.css
@@ -1534,14 +1534,12 @@ body[data-page-id="login-trusted-device-register"] #kc-form-trusted-device {
 }
 
 /* On mobile the No/Yes labels are too long to share a row — stack the pair */
-/* full-width with the primary (Yes, trust this device) on top. Desktop keeps */
-/* the side-by-side No | Yes order from the Figma frame. */
+/* full-width on two rows, "No, require verification each time" above the */
+/* primary Yes (plain DOM order), per Figma 14641:35974. Desktop keeps the */
+/* side-by-side No | Yes pair. */
 @media (max-width: 767px) {
   body[data-page-id="login-trusted-device-register"] .tp-totp-actions {
     grid-template-columns: 1fr;
-  }
-  body[data-page-id="login-trusted-device-register"] .tp-totp-actions > .pf-m-primary {
-    order: -1;
   }
 }
 

--- a/tidepool-theme/login/resources/css/tidepool.css
+++ b/tidepool-theme/login/resources/css/tidepool.css
@@ -1326,6 +1326,26 @@ body[data-page-id="login-login-recovery-authn-code-input"] .tp-otp-disclaimer {
 /* The bare checkbox here is skinned by the shared .pf-v5-c-check__input rule */
 /* group near the top of this file. */
 
+/* Invisible default submit. Implicit submission (Enter in a text field) */
+/* clicks the form's FIRST submit button, and our action rows put Cancel */
+/* before the primary to match the Figma left-to-right order — so Enter */
+/* would cancel instead of submit. Forms with both a text field and a */
+/* leading Cancel submit render this stub as their first submit so Enter */
+/* performs the primary action. Off-screen rather than display:none so */
+/* every browser still treats it as the default button; tabindex="-1" and */
+/* aria-hidden keep it out of the tab order and accessibility tree. */
+.tp-default-submit {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
 /* Side-by-side action buttons (Cancel/Back + primary). 1fr each, equal width, */
 /* matching the figma's 50/50 split with a 12px gap between them. */
 .tp-totp-actions {

--- a/tidepool-theme/login/resources/css/tidepool.css
+++ b/tidepool-theme/login/resources/css/tidepool.css
@@ -189,7 +189,7 @@ body.tp-role-clinician #kc-header-wrapper {
 .pf-v5-c-login__main-header {
   border-top: none;
   padding: 0;
-  margin-bottom: 48px;
+  margin-bottom: 32px;
   display: block;
 }
 
@@ -260,7 +260,7 @@ body.tp-role-clinician #kc-header-wrapper {
   color: var(--tp-color-blue-50);
 }
 
-/* Form group spacing: 16px between rows, then a larger 48px gap before the */
+/* Form group spacing: 16px between rows, then a larger 32px gap before the */
 /* action button (the last form group, which wraps the primary submit). */
 /* Applied to both the login form and the registration form. */
 #kc-form-login,
@@ -274,15 +274,15 @@ body.tp-role-clinician #kc-header-wrapper {
 
 #kc-form-login > .pf-v5-c-form__group:last-child,
 #kc-register-form > .pf-v5-c-form__group:last-child {
-  margin-top: 32px;
+  margin-top: 16px;
 }
 
-/* update-email.ftl / login-update-password.ftl: 48px between the last form */
+/* update-email.ftl / login-update-password.ftl: 32px between the last form */
 /* item (the "Log out of other devices" checkbox) and the action buttons. */
-/* Parent gap already gives 16px, so add another 32px on the actions row. */
+/* Parent gap already gives 16px, so add another 16px on the actions row. */
 #kc-update-email-form > .tp-totp-actions,
 #kc-passwd-update-form > .tp-totp-actions {
-  margin-top: 32px;
+  margin-top: 16px;
 }
 
 /* Form group / label. */
@@ -821,16 +821,16 @@ body.tp-role-clinician #kc-header-wrapper {
 }
 
 #tp-role-prompt > .pf-v5-c-form__group:last-child {
-  margin-top: 32px;
+  margin-top: 16px;
 }
 
 /* Personal-account terms screen (patient_terms.ftl) — Figma node 11691:48930. */
-/* Two stacked groups (age radios, terms acceptance) separated by the same 48px */
+/* Two stacked groups (age radios, terms acceptance) separated by the same 32px */
 /* the card uses everywhere; the title→age gap comes from the main-header margin. */
 .tp-terms {
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 32px;
 }
 
 /* Age radio group: gray copy beside a custom 14px indigo radio. */
@@ -936,7 +936,7 @@ body.tp-role-clinician #kc-header-wrapper {
   color: var(--tp-color-blue-60);
 }
 
-/* Card sections spaced on the Figma's 48px rhythm (cards → Next → disclaimer) */
+/* Card sections spaced on the design's 32px rhythm (cards → Next → disclaimer) */
 /* rather than the default 16px row gap. The IDP-selection and authenticator */
 /* picker forms set their own flex; the OTP / recovery-input forms are already */
 /* flex via .pf-v5-c-form, so they only need the wider gap. */
@@ -944,26 +944,26 @@ body.tp-role-clinician #kc-header-wrapper {
 body[data-page-id="login-select-authenticator"] #kc-select-credential-form {
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 32px;
 }
 
 body[data-page-id="login-login-otp"] #kc-otp-login-form,
 body[data-page-id="login-login-recovery-authn-code-input"] #kc-recovery-code-login-form {
-  gap: 48px;
+  gap: 32px;
 }
 
 /* On these forms the submit button is the final group; suppress the shared */
-/* 32px last-child margin-top since the 48px parent gap already spaces it. */
+/* 16px last-child margin-top since the 32px parent gap already spaces it. */
 body[data-page-id="login-select-authenticator"] #kc-select-credential-form > .pf-v5-c-form__group:last-child,
 body[data-page-id="login-login-otp"] #kc-otp-login-form > .pf-v5-c-form__group:last-child,
 body[data-page-id="login-login-recovery-authn-code-input"] #kc-recovery-code-login-form > .pf-v5-c-form__group:last-child {
   margin-top: 0;
 }
 
-/* 48px between the picker form and the disclaimer block below it. */
+/* 32px between the picker form and the disclaimer block below it. */
 #kc-idp-select-form + .tp-otp-disclaimer,
 body[data-page-id="login-select-authenticator"] .tp-otp-disclaimer {
-  margin-top: 48px;
+  margin-top: 32px;
 }
 
 /* Subtitle override shared by the IDP-selection and IDP-link-email pages — */
@@ -982,13 +982,13 @@ body[data-page-id="login-login-idp-link-email"] .tp-login-subtitle {
   gap: 4px;
 }
 
-/* The OTP form uses a uniform 48px flex gap between children, but the warning */
+/* The OTP form uses a uniform 32px flex gap between children, but the warning */
 /* banner, device hint, and code input should sit in a tight 16px stack (per */
-/* Figma). Pull each down 32px so those gaps are 16px while the gap before the */
-/* submit button stays 48px. */
+/* Figma). Pull each down 16px so those gaps are 16px while the gap before the */
+/* submit button stays 32px. */
 body[data-page-id="login-login-otp"] #kc-otp-login-form > .tp-warning-banner,
 body[data-page-id="login-login-otp"] #kc-otp-login-form > .tp-otp-device {
-  margin-bottom: -32px;
+  margin-bottom: -16px;
 }
 
 .tp-otp-device-hint {
@@ -1054,17 +1054,17 @@ body[data-page-id="login-login-otp"] #kc-otp-login-form > .tp-otp-device {
 /* The template-level fallback form is hidden globally via */
 /* #kc-select-try-another-way-form; this one (#tp-otp-try-another-way) is the */
 /* visible Tidepool-styled replacement. */
-/* 48px top margin matches the in-card section rhythm from the Figma design — */
+/* 32px top margin matches the in-card section rhythm from the design — */
 /* the main form's flex gap doesn't reach here because this form is a sibling, */
 /* not a child of #kc-otp-login-form. */
 #tp-otp-try-another-way,
 #tp-recovery-try-another-way {
-  margin: 48px 0 0;
+  margin: 32px 0 0;
 }
 
 body[data-page-id="login-login-otp"] .tp-otp-disclaimer,
 body[data-page-id="login-login-recovery-authn-code-input"] .tp-otp-disclaimer {
-  margin-top: 48px;
+  margin-top: 32px;
 }
 
 .tp-otp-try-another-way {
@@ -1131,7 +1131,7 @@ body[data-page-id="login-login-recovery-authn-code-input"] .tp-otp-disclaimer {
 .tp-totp-form {
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 32px;
 }
 
 .tp-totp-form[data-step="qr"] .tp-totp-step--verify,
@@ -1142,7 +1142,7 @@ body[data-page-id="login-login-recovery-authn-code-input"] .tp-otp-disclaimer {
 .tp-totp-step {
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 32px;
 }
 
 .tp-totp-section-title {
@@ -1280,9 +1280,9 @@ body[data-page-id="login-login-recovery-authn-code-input"] .tp-otp-disclaimer {
 }
 
 /* Stack the two form fields with the figma's 16px rhythm — tighter than the */
-/* 48px section gap because they belong to one logical group. */
+/* 32px section gap because they belong to one logical group. */
 .tp-totp-step--verify > .pf-v5-c-form__group + .pf-v5-c-form__group {
-  margin-top: -32px;
+  margin-top: -16px;
 }
 
 .tp-totp-logout {
@@ -1379,8 +1379,8 @@ body[data-page-id="login-login-recovery-authn-code-input"] .tp-otp-disclaimer {
 
 /* login-idp-link-email.ftl: the form body stacks a warning banner, a helper */
 /* block, the read-only email field, then the action buttons. main-body has no */
-/* gap of its own, so space the children explicitly (16px between rows, +32px */
-/* before the buttons for a 48px break per the Figma frame). */
+/* gap of its own, so space the children explicitly (16px between rows, +16px */
+/* before the buttons for a 32px break per the design). */
 body[data-page-id="login-login-idp-link-email"] .pf-v5-c-login__main-body {
   display: flex;
   flex-direction: column;
@@ -1388,7 +1388,7 @@ body[data-page-id="login-login-idp-link-email"] .pf-v5-c-login__main-body {
 }
 
 body[data-page-id="login-login-idp-link-email"] .tp-totp-actions {
-  margin-top: 32px;
+  margin-top: 16px;
 }
 
 /* Two-line helper text under the warning banner: 16px blue-60 body copy with a */
@@ -1414,19 +1414,19 @@ body[data-page-id="login-login-idp-link-email"] .tp-totp-actions {
   color: var(--tp-color-blue-60);
 }
 
-/* delete-credential: 48px below to match the design's body→buttons gap. */
+/* delete-credential: 32px below to match the design's body→buttons gap. */
 .tp-delete-credential-message {
-  margin-bottom: 48px;
+  margin-bottom: 32px;
 }
 
 /* Broker link confirmation (login-idp-link-confirm.ftl) — Figma node */
 /* 13831:31031. Body prose then a full-width Next button, separated by the */
-/* same 48px the card uses elsewhere; the title→body gap comes from the */
+/* same 32px the card uses elsewhere; the title→body gap comes from the */
 /* main-header margin. */
 .tp-idp-link-confirm {
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 32px;
 }
 
 /* Two paragraphs of blue-60 body copy; the blank line between them in the */
@@ -1457,7 +1457,7 @@ a.tp-back-to-app.pf-v5-c-button {
 
 /* Space the back-to-app button away from the message text above it. */
 .tp-back-to-app {
-  margin-top: 48px;
+  margin-top: 32px;
 }
 
 /* Body message text (error.ftl, info.ftl, etc.) — medium weight, 16px/20px. */
@@ -1467,14 +1467,21 @@ a.tp-back-to-app.pf-v5-c-button {
   line-height: 20px;
 }
 
+/* logout-confirm: the Logout button renders in a bare .form-actions form with */
+/* no spacing of its own, landing flush against the prose — give it the same */
+/* 32px section gap the other cards use. */
+#kc-logout-confirm .form-actions {
+  margin-top: 32px;
+}
+
 /* Trusted device prompt (trusted-device-register.ftl) — overrides the basic */
 /* SPI-bundled template to match Figma node 11629:21144. Two body paragraphs */
-/* sit above a side-by-side No/Yes action pair using the shared 48px section */
+/* sit above a side-by-side No/Yes action pair using the shared 32px section */
 /* rhythm. */
 body[data-page-id="login-trusted-device-register"] #kc-form-trusted-device {
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 32px;
 }
 
 .tp-trusted-device-explanation {
@@ -1484,11 +1491,11 @@ body[data-page-id="login-trusted-device-register"] #kc-form-trusted-device {
 }
 
 /* Recovery codes config (login-recovery-authn-code-config.ftl). Figma node */
-/* 11627:14617. Sections separated by 48px (matching other 2FA screens). */
+/* 11627:14617. Sections separated by 32px (matching other 2FA screens). */
 body[data-page-id="login-login-recovery-authn-code-config"] .pf-v5-c-login__main-body {
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 32px;
 }
 
 /* Intro: "Download recovery codes" + description + learn-more link. */
@@ -1530,7 +1537,7 @@ body[data-page-id="login-login-recovery-authn-code-config"] .pf-v5-c-login__main
 
 /* Wrapping block: warning banner + code list + actions sit together in a */
 /* tight 16px stack, separated from the surrounding sections by the parent's */
-/* 48px gap. */
+/* 32px gap. */
 .tp-recovery-codes-block {
   display: flex;
   flex-direction: column;
@@ -1756,10 +1763,12 @@ body[data-page-id="login-login-recovery-authn-code-config"] .pf-v5-c-login__main
   padding-top: 0;
 }
 
-/* On the password-reset page, the design calls for 48px between the email */
-/* row and the Next button (Figma). Add the extra margin scoped to that form. */
+/* On the password-reset page, the design calls for 32px between the email */
+/* row and the Next button. The form's 24px grid gap plus PF's intrinsic */
+/* actions offset (4px padding-top + 8px button margin-top) already total */
+/* 36px — pull up 4px to land on 32px. */
 #kc-reset-password-form .pf-v5-c-form__actions {
-  margin-top: 12px;
+  margin-top: -4px;
 }
 
 /* template.ftl renders two .pf-v5-c-login__main-footer wrappers: one for */
@@ -1785,10 +1794,10 @@ body[data-page-id="login-login-recovery-authn-code-config"] .pf-v5-c-login__main
 
 #kc-info {
   text-align: center;
-  /* Figma uses a uniform 48px gap between card sections. #kc-info is the */
+  /* The design uses a uniform 32px gap between card sections. #kc-info is the */
   /* last section (Sign Up) and sits in the card's main-footer wrapper, */
   /* outside #kc-form-login's flex gap — apply the spacing explicitly. */
-  margin-top: 48px;
+  margin-top: 32px;
 }
 
 #kc-info,

--- a/tidepool-theme/login/resources/css/tidepool.css
+++ b/tidepool-theme/login/resources/css/tidepool.css
@@ -1171,9 +1171,9 @@ body[data-page-id="login-login-recovery-authn-code-input"] .tp-otp-disclaimer {
 }
 
 .tp-totp-apps-list {
-  list-style: none;
+  list-style: disc;
   margin: 0;
-  padding: 0 0 0 12px;
+  padding: 0 0 0 24px;
   display: flex;
   flex-direction: column;
   gap: 4px;

--- a/tidepool-theme/login/resources/css/tidepool.css
+++ b/tidepool-theme/login/resources/css/tidepool.css
@@ -1701,6 +1701,29 @@ body[data-page-id="login-login-recovery-authn-code-config"] .pf-v5-c-login__main
   text-align: right;
 }
 
+/* On mobile the side-by-side columns (~390px of max-content tracks) overflow */
+/* the card. The mobile frame (Figma 14647:38700) stacks the codes in a single */
+/* centered column instead: 1..6 and 7..12 as two groups with a 44px gap */
+/* between them (40px margin + the 4px row gap). */
+@media (max-width: 767px) {
+  /* The tinted box spans the card on mobile instead of shrink-wrapping to */
+  /* the code column (which .tp-recovery-codes-block's align-items would do). */
+  .tp-recovery-codes {
+    width: 100%;
+    box-sizing: border-box;
+  }
+  .tp-recovery-codes-list {
+    grid-template-columns: max-content;
+    grid-template-rows: none;
+    grid-auto-flow: row;
+    width: max-content;
+    margin: 0 auto;
+  }
+  .tp-recovery-codes-list li:nth-child(7) {
+    margin-top: 40px;
+  }
+}
+
 /* Download / Copy action row — text + icon, no button chrome. */
 .tp-recovery-actions {
   display: flex;

--- a/tidepool-theme/login/resources/css/tidepool.css
+++ b/tidepool-theme/login/resources/css/tidepool.css
@@ -209,6 +209,10 @@ body.tp-role-clinician #kc-header-wrapper {
   text-align: center;
   margin: 0;
   line-height: 24px;
+  /* Some titles interpolate user-entered device labels (delete-credential's */
+  /* "Delete {0}") which can be a single unbroken 200-char string — allow */
+  /* mid-word breaks rather than relying on PF's .pf-v5-c-title word-break. */
+  overflow-wrap: anywhere;
 }
 
 /* Form body spacing. */
@@ -1005,6 +1009,9 @@ body[data-page-id="login-login-otp"] #kc-otp-login-form > .tp-otp-device {
   font-weight: 500;
   line-height: 20px;
   color: #000;
+  /* User-entered device label — same unbroken-string hazard as the */
+  /* delete-credential message. */
+  overflow-wrap: anywhere;
 }
 
 /* Multi-credential selector (when the user has more than one OTP registered). */
@@ -1047,6 +1054,10 @@ body[data-page-id="login-login-otp"] #kc-otp-login-form > .tp-otp-device {
   font-weight: 500;
   line-height: 20px;
   color: var(--tp-color-brand-purple);
+  /* User-entered device label inside a flex row — allow mid-word breaks and */
+  /* let the item shrink instead of widening the credential card. */
+  overflow-wrap: anywhere;
+  min-width: 0;
 }
 
 /* "Can't access your device right now? Try a Different Log In Method" — */
@@ -1412,6 +1423,10 @@ body[data-page-id="login-login-idp-link-email"] .tp-totp-actions {
   font-weight: 500;
   line-height: 20px;
   color: var(--tp-color-blue-60);
+  /* The delete-credential / idp-link messages interpolate user- or admin- */
+  /* entered names that can exceed a full line unbroken — break rather than */
+  /* creep out of the card. */
+  overflow-wrap: anywhere;
 }
 
 /* delete-credential: 32px below to match the design's body→buttons gap. */

--- a/tidepool-theme/login/resources/css/tidepool.css
+++ b/tidepool-theme/login/resources/css/tidepool.css
@@ -129,6 +129,19 @@ body.login-pf,
   max-width: 600px;
 }
 
+/* Mobile spacing (iPhone SE Figma frame 14642:38389): 32px/24px page padding */
+/* and a 24px logo-to-card gap instead of the desktop 48px values. The card's */
+/* own 32px padding and the 32px section rhythm inside it are the same on */
+/* both frames, so only the page scaffold changes here. */
+@media (max-width: 767px) {
+  .pf-v5-c-login {
+    padding: 32px 24px;
+  }
+  .pf-v5-c-login__container {
+    gap: 24px;
+  }
+}
+
 /* Header: swap keycloak text logo for the Tidepool wordmark image. */
 /* Override the upstream margin-top: 64px (which also collapses to 0 at some */
 /* breakpoints, causing the gap to disappear on smaller screens). Anchor the */

--- a/tidepool-theme/login/resources/css/tidepool.css
+++ b/tidepool-theme/login/resources/css/tidepool.css
@@ -1416,6 +1416,7 @@ body[data-page-id="login-login-idp-link-email"] .tp-totp-actions {
 .tp-delete-credential-message,
 .tp-idp-link-help p,
 .tp-idp-link-confirm-body p,
+.tp-link-expired-message,
 .tp-trusted-device-explanation p {
   margin: 0;
   font-family: var(--tp-font-family);

--- a/tidepool-theme/login/template.ftl
+++ b/tidepool-theme/login/template.ftl
@@ -251,7 +251,7 @@
               <#-- Only render the info band when the page actually supplies info -->
               <#-- content. Some pages (e.g. hidpd-select-idp.ftl) enable displayInfo -->
               <#-- for registration but define no "info" section; rendering it anyway -->
-              <#-- leaves an empty #kc-info band that still reserves its 48px top -->
+              <#-- leaves an empty #kc-info band that still reserves its 32px top -->
               <#-- margin. Capture the section output and skip the band when blank. -->
               <#if displayInfo>
                   <#local infoContent><#nested "info"></#local>

--- a/tidepool-theme/login/tp-commons.ftl
+++ b/tidepool-theme/login/tp-commons.ftl
@@ -7,6 +7,37 @@
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
 </#macro>
 
+<#-- True when the current page renders the error from an expired action-token -->
+<#-- link (password reset, email verification, update-email confirmation). -->
+<#-- Keycloak surfaces the expiry through different message keys depending on -->
+<#-- whether an auth session exists (flow restart uses ...SessionExists, the -->
+<#-- no-session error page uses ...NoSession, and required-action expiry uses -->
+<#-- expiredActionMessage) — treat them all as the same "link expired" state. -->
+<#function isActionLinkExpired>
+    <#if !(message??) || message.type != 'error'>
+        <#return false>
+    </#if>
+    <#local summary = message.summary?trim>
+    <#return summary == msg("expiredActionMessage")?trim
+        || summary == msg("expiredActionTokenNoSessionMessage")?trim
+        || summary == msg("expiredActionTokenSessionExistsMessage")?trim>
+</#function>
+
+<#-- The dedicated link-expired card body (Figma node 14515:80071): blue-60 -->
+<#-- prose plus a full-width primary "Take me back to the application" button. -->
+<#-- Falls back to restarting the login flow when the client has no base URL. -->
+<#macro linkExpiredBody>
+    <div id="tp-link-expired">
+        <p class="tp-link-expired-message">${msg("linkExpiredMessage")}</p>
+        <#if client?? && client.baseUrl?has_content>
+            <#local backUrl = client.baseUrl>
+        <#else>
+            <#local backUrl = url.loginRestartFlowUrl>
+        </#if>
+        <a id="backToApplication" href="${backUrl}" class="${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} tp-back-to-app">${msg("backToApplication")}</a>
+    </div>
+</#macro>
+
 <#-- "Having trouble logging in? / Important:" disclaimer at the bottom of the OTP, -->
 <#-- recovery-code, authenticator-select, and IDP-select screens. The second -->
 <#-- ("Important:") paragraph is omitted on the IDP-select screen (showImportant=false). -->

--- a/tidepool-theme/login/update-email.ftl
+++ b/tidepool-theme/login/update-email.ftl
@@ -25,6 +25,9 @@
         </#if>
         <#assign emailError = messagesPerField.get('email')>
         <form id="kc-update-email-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+            <#-- Default submit for Enter — the visible Cancel submit renders before -->
+            <#-- the primary, so without this stub implicit submission would cancel. -->
+            <input type="submit" class="tp-default-submit" tabindex="-1" aria-hidden="true"/>
             <@field.input name="email" label=msg("updateEmailFieldLabel") value=emailValue error=emailError fieldName="email" autofocus=true autocomplete="email" />
 
             <div class="tp-totp-logout">


### PR DESCRIPTION
Design-review fixes on top of the theme redesign (#54):

- **Copy** — login-page copy per the design review, the 2FA-setup support link, and the update-email confirmation page + pending-change info alert matched to the Figma frames.
- **Layout / mobile** — 32px card section rhythm, reordered 2FA verify fields with a bulleted authenticator-app list, tighter mobile page padding and logo-to-card gap, recovery codes in a single column, the trusted-device pair stacked with No above Yes, and mid-word wrapping for long user-entered device labels.
- **Behavior** — a dedicated "This link is no longer active" card for expired action-token links, Sign Up stays disabled until the registration form is complete, and Enter now submits the primary action instead of Cancel (hidden default-submit stub on the update-email, update-password, TOTP-setup, and recovery-codes forms — the visible Cancel renders first, so implicit submission used to cancel).

---

📚 **Stacked PR 9 of 9 (final).** Base branch: `tk-stack-8-theme-redesign` — review/merge it first.

**Stack — review & merge bottom-up:**

1. `tk-stack-1-trusted-device-spi` → `master`
2. `tk-stack-2-attempted-username-fix` → `tk-stack-1-trusted-device-spi`
3. `tk-stack-3-aia-authenticator` → `tk-stack-2-attempted-username-fix`
4. `tk-stack-4-2fa-cleanup-listeners` → `tk-stack-3-aia-authenticator`
5. `tk-stack-5-login-activity-outbox` → `tk-stack-4-2fa-cleanup-listeners`
6. `tk-stack-6-email-changed-notification` → `tk-stack-5-login-activity-outbox`
7. `tk-stack-7-cancelable-email-change` → `tk-stack-6-email-changed-notification`
8. `tk-stack-8-theme-redesign` → `tk-stack-7-cancelable-email-change`
9. `tk-stack-9-design-review-fixes` → `tk-stack-8-theme-redesign`

_Theme-only diff (FTL / CSS / message properties — no Java). Flows verified live against the local dev1 realm._