### PR TITLE
[BACK-4437] Address code-review feedback

### DIFF
--- a/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProvider.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/activity/UserActivityEventListenerProvider.java
@@ -148,7 +148,7 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
             // A specific credential was deleted by an admin (relabel/reorder are not deletions).
             recordMfaCredentialChange(realmId, userId, event.getTime(), null, true);
         }
-        // Admins cannot enrol a second factor for a user, so there is no admin "credential added" path.
+        // Admins cannot enroll a second factor for a user, so there is no admin "credential added" path.
     }
 
     private void recordLogin(String realmId, String userId, String sessionId, long time) {
@@ -199,14 +199,14 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
 
     /**
      * Records an MFA enable/disable row based on the kind of credential change, without consulting any
-     * stored history. {@code removed} marks a credential removal (→ possibly {@code MFA_DISABLED});
-     * otherwise it is an add/update (→ possibly {@code MFA_ENABLED}). The recorded row always reflects
-     * the user's true current MFA state.
+     * stored history. {@code credentialRemoved} marks a credential removal (→ possibly
+     * {@code MFA_DISABLED}); otherwise it is an add/update (→ possibly {@code MFA_ENABLED}). The
+     * recorded row always reflects the user's true current MFA state.
      *
      * @param credentialType the changed credential's type if known, else {@code null}.
      */
     private void recordMfaCredentialChange(String realmId, String userId, long time,
-                                           String credentialType, boolean removed) {
+                                           String credentialType, boolean credentialRemoved) {
         // If we know which credential changed and it is not a second factor, MFA state cannot have
         // changed — skip the user lookup and credential scan entirely (e.g. password changes).
         if (credentialType != null && !MFA_CREDENTIAL_TYPES.contains(credentialType)) {
@@ -225,7 +225,7 @@ public class UserActivityEventListenerProvider implements EventListenerProvider 
         boolean hasMfa = hasMfaCredential(user);
         // Removal counts as disabled only once no second factor remains (removing one of two stays
         // enabled); an add/update counts as enabled while a second factor is present.
-        if (removed == hasMfa) {
+        if (credentialRemoved == hasMfa) {
             return;
         }
         recorder.recordMfa(realmId, userId, hasMfa, time);

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/authenticator/ConditionAppInitiatedActionFactory.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/authenticator/ConditionAppInitiatedActionFactory.java
@@ -69,7 +69,7 @@ public final class ConditionAppInitiatedActionFactory implements AuthenticatorFa
         negate.setName(CONF_NEGATE);
         negate.setLabel("Negate output");
         negate.setDefaultValue(Boolean.toString(true));
-        negate.setHelpText("Apply a NOT to the check result. When this is true, the condition evaluates to true when the flow was NOT triggered by an Application-Initiated Action.");
+        negate.setHelpText("Negate the conditional check. When true, the condition passes when the flow was NOT triggered by an Application-Initiated Action.");
         return List.of(negate);
     }
 

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/events/EmailChangedNotificationEventListenerProvider.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/events/EmailChangedNotificationEventListenerProvider.java
@@ -121,11 +121,11 @@ public class EmailChangedNotificationEventListenerProvider implements EventListe
                     .setRealm(realm)
                     .setUser(previousEmailRecipient)
                     .send(SUBJECT_MESSAGE_KEY, TEMPLATE_NAME, attributes);
-            LOG.infof("Sent email-change notification to the previous address of user %s in realm %s",
-                    userId, realm.getName());
+            LOG.infof("Sent email-change notification to the previous address %s of user %s in realm %s",
+                    previousEmail, userId, realm.getName());
         } catch (EmailException e) {
-            LOG.warnf(e, "Failed to send email-change notification to the previous address of user %s in realm %s",
-                    userId, realm.getName());
+            LOG.warnf(e, "Failed to send email-change notification to the previous address %s of user %s in realm %s",
+                    previousEmail, userId, realm.getName());
         }
     }
 

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/events/RecoveryCodesCleanupEventListenerProvider.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/events/RecoveryCodesCleanupEventListenerProvider.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
  *
  * <p>Tidepool issues recovery codes only as a backup for OTP-based two-factor authentication.
  * Leaving them behind after every OTP credential is gone would let a user keep a second factor
- * they can no longer use to enrol an authenticator, so we clean them up.
+ * they can no longer use to enroll an authenticator, so we clean them up.
  *
  * <p>When a user removes an OTP device via self-service (the account console or an app-initiated
  * action), Keycloak fires {@link EventType#REMOVE_TOTP} <em>after</em> the credential has already

--- a/admin/src/main/java/org/tidepool/keycloak/extensions/events/TrustedDeviceCleanupEventListenerProvider.java
+++ b/admin/src/main/java/org/tidepool/keycloak/extensions/events/TrustedDeviceCleanupEventListenerProvider.java
@@ -19,8 +19,8 @@ import java.util.stream.Collectors;
  *
  * <p>A trusted device lets a user skip two-factor authentication on a previously verified device.
  * When the password changes &mdash; whether the user updates it themselves or completes a
- * forgot-password reset &mdash; any existing trust should be revoked, so a new password cannot ride
- * on a device that was trusted under the old one.
+ * forgot-password reset &mdash; any existing trust should be revoked, so trust established under
+ * the old password does not carry over to the new one.
  *
  * <p>Keycloak fires {@link EventType#UPDATE_PASSWORD} after the password has been set, for both the
  * self-service "update password" action and the reset-credentials (forgot-password) flow. We react


### PR DESCRIPTION
Addresses the smaller code-review comments from #49, #50, #51 and #52:

- Reworded the negate-option help text of the AIA conditional authenticator (https://github.com/tidepool-org/keycloak-extensions/pull/49#discussion_r3684314806)
- `enrol` -> `enroll` in two comments (https://github.com/tidepool-org/keycloak-extensions/pull/50#discussion_r3688899643, https://github.com/tidepool-org/keycloak-extensions/pull/51#discussion_r3689364858)
- Reworded the confusing "a new password cannot ride" sentence in the trusted-device cleanup javadoc (https://github.com/tidepool-org/keycloak-extensions/pull/50#discussion_r3688964730)
- Renamed the `removed` parameter of `recordMfaCredentialChange` to `credentialRemoved` so it does not read as the opposite of `recordMfa`'s `mfaEnabled` (https://github.com/tidepool-org/keycloak-extensions/pull/51#discussion_r3689440886)
- Included the recipient address in the email-change notification logs (https://github.com/tidepool-org/keycloak-extensions/pull/52#discussion_r3699737879)

The remaining review comments (outbox schema types, `COUNT(e)`, the setRealm issue) are answered with replies on the PRs instead of code changes.